### PR TITLE
OJ-1956: Add error handling to `post-ivq-answers`

### DIFF
--- a/lambdas/submit-answer/src/submit-answer-handler.ts
+++ b/lambdas/submit-answer/src/submit-answer-handler.ts
@@ -1,30 +1,38 @@
 import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { Logger } from "@aws-lambda-powertools/logger";
+
+const logger = new Logger();
 
 export class SubmitAnswerHandler implements LambdaInterface {
   public async handler(event: any, _context: unknown): Promise<string> {
-    const answers = event.questions.Items.map((question: any) => {
-      return {
-        questionKey: question.questionKey.S,
-        answer: question.answer.S,
-      };
-    });
+    try {
+      const answers = event.questions.Items.map((question: any) => {
+        return {
+          questionKey: question.questionKey.S,
+          answer: question.answer.S,
+        };
+      });
 
-    const response = await fetch(event.parameters.url, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "User-Agent": event.parameters.userAgent,
-        Authorization: "Bearer " + event.oAuthToken.value,
-      },
-      body: JSON.stringify({
-        correlationId: event.questions.Items[0].correlationId.S,
-        selection: {
-          nino: event.nino,
+      const response = await fetch(event.parameters.url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "User-Agent": event.parameters.userAgent,
+          Authorization: "Bearer " + event.oAuthToken.value,
         },
-        answers: answers,
-      }),
-    });
-    return await response.json();
+        body: JSON.stringify({
+          correlationId: event.questions.Items[0].correlationId.S,
+          selection: {
+            nino: event.nino,
+          },
+          answers: answers,
+        }),
+      });
+      return await response.json();
+    } catch (error: any) {
+      logger.error("Failed to call HMRC API: " + error.message);
+      throw error;
+    }
   }
 }
 

--- a/step-functions/post-answer.asl.json
+++ b/step-functions/post-answer.asl.json
@@ -162,7 +162,16 @@
         }
       ],
       "Next": "Fetch Auth Code Expiry",
-      "ResultPath": null
+      "ResultPath": null,
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Err: Post IVQ Answers threw Exception"
+        }
+      ]
+    },
+    "Err: Post IVQ Answers threw Exception": {
+      "Type": "Fail"
     },
     "Fetch Auth Code Expiry": {
       "Type": "Task",

--- a/step-functions/post-ivq-answers.asl.json
+++ b/step-functions/post-ivq-answers.asl.json
@@ -71,7 +71,7 @@
     "Fetch API URL and User Agent": {
       "Type": "Task",
       "Parameters": {
-        "Names": ["/suraj-kbv-hmrc/AnswersUrl", "/suraj-kbv-hmrc/UserAgent"]
+        "Names": ["${AnswersUrlName}", "${UserAgentName}"]
       },
       "Resource": "arn:aws:states:::aws-sdk:ssm:getParameters",
       "Next": "Post answers to HMRC",

--- a/step-functions/post-ivq-answers.asl.json
+++ b/step-functions/post-ivq-answers.asl.json
@@ -4,7 +4,7 @@
   "States": {
     "Get all Unanswered Questions": {
       "Type": "Task",
-      "Next": "All Questions Answered",
+      "Next": "All Questions Answered?",
       "Parameters": {
         "TableName": "${QuestionsTableName}",
         "KeyConditionExpression": "sessionId = :value",
@@ -21,20 +21,20 @@
       "Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
       "ResultPath": "$.questions"
     },
-    "All Questions Answered": {
+    "All Questions Answered?": {
       "Type": "Choice",
       "Choices": [
         {
           "Variable": "$.questions.Count",
           "NumericGreaterThan": 0,
-          "Next": "Do Nothing"
+          "Next": "Nothing left to do"
         }
       ],
       "Default": "Get all Answered Questions"
     },
     "Get all Answered Questions": {
       "Type": "Task",
-      "Next": "GetSecretValue",
+      "Next": "Fetch Bearer Token",
       "Parameters": {
         "TableName": "${QuestionsTableName}",
         "KeyConditionExpression": "sessionId = :value",
@@ -51,9 +51,9 @@
       "Resource": "arn:aws:states:::aws-sdk:dynamodb:query",
       "ResultPath": "$.questions"
     },
-    "GetSecretValue": {
+    "Fetch Bearer Token": {
       "Type": "Task",
-      "Next": "GetParameters",
+      "Next": "Fetch API URL and User Agent",
       "Parameters": {
         "SecretId": "${BearerTokenName}"
       },
@@ -63,24 +63,25 @@
       },
       "ResultPath": "$.oAuthToken"
     },
-    "Do Nothing": {
+    "Nothing left to do": {
       "Type": "Pass",
-      "End": true
+      "End": true,
+      "Result": {}
     },
-    "GetParameters": {
+    "Fetch API URL and User Agent": {
       "Type": "Task",
       "Parameters": {
-        "Names": ["${AnswersUrlName}", "${UserAgentName}"]
+        "Names": ["/suraj-kbv-hmrc/AnswersUrl", "/suraj-kbv-hmrc/UserAgent"]
       },
       "Resource": "arn:aws:states:::aws-sdk:ssm:getParameters",
-      "Next": "Lambda Invoke",
+      "Next": "Post answers to HMRC",
       "ResultSelector": {
         "url.$": "$.Parameters[0].Value",
         "userAgent.$": "$.Parameters[1].Value"
       },
       "ResultPath": "$.parameters"
     },
-    "Lambda Invoke": {
+    "Post answers to HMRC": {
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",
       "OutputPath": "$.Payload",
@@ -101,7 +102,16 @@
           "BackoffRate": 2
         }
       ],
-      "Next": "Store Result"
+      "Next": "Store Result",
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "Err: Lambda threw exception"
+        }
+      ]
+    },
+    "Err: Lambda threw exception": {
+      "Type": "Fail"
     },
     "Store Result": {
       "Type": "Map",
@@ -135,8 +145,8 @@
           }
         }
       },
-      "End": true,
-      "InputPath": "$"
+      "InputPath": "$",
+      "Next": "Nothing left to do"
     }
   }
 }


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
Added error handling to the `post-ivq-answers` state machine.
try-catch-throw to `SubmitAnswerHandler` so we can handle HMRC errors 
Updated `post-answers` state machine so that if `post-ivq-answers` fails, it is handled

<!-- Describe the changes in detail - the "what"-->

### Why did it change

<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1956](https://govukverify.atlassian.net/browse/OJ-1956)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [X] No environment variables or secrets were added or changed

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-1956]: https://govukverify.atlassian.net/browse/OJ-1956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ