### PR TITLE
OJ-1959: `submit-answer-handler` unit tests

### DIFF
--- a/lambdas/submit-answer/src/submit-answer-handler.ts
+++ b/lambdas/submit-answer/src/submit-answer-handler.ts
@@ -28,7 +28,11 @@ export class SubmitAnswerHandler implements LambdaInterface {
           answers: answers,
         }),
       });
-      return await response.json();
+      try {
+        return await response.json();
+      } catch (error: any) {
+        return await response.text();
+      }
     } catch (error: any) {
       logger.error("Failed to call HMRC API: " + error.message);
       throw error;

--- a/lambdas/submit-answer/tests/submit-answer-handler.test.ts
+++ b/lambdas/submit-answer/tests/submit-answer-handler.test.ts
@@ -2,9 +2,122 @@ import { SubmitAnswerHandler } from "../src/submit-answer-handler";
 import { Context } from "aws-lambda";
 
 describe("submit-answer-handler", () => {
-  it("should print Hello, World!", async () => {
-    const submitAnswerHandler = new SubmitAnswerHandler();
-    const result = await submitAnswerHandler.handler({}, {} as Context);
-    expect(result).toStrictEqual("Hello, World!");
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+
+  describe("happy path scenarios", () => {
+    it("it should return the response from the HMRC API", async () => {
+      const hmrcResponse = {};
+      global.fetch = jest.fn();
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        json: jest.fn().mockResolvedValueOnce(hmrcResponse),
+      });
+      const submitAnswerHandler = new SubmitAnswerHandler();
+      const result = await submitAnswerHandler.handler(
+        {
+          nino: "good-nino",
+          parameters: {
+            url: "testUrl",
+            userAgent: "testUserAgent",
+          },
+          oAuthToken: {
+            value: "testOAuthToken",
+          },
+          questions: {
+            Items: [
+              {
+                correlationId: {
+                  S: "testCorrelationId",
+                },
+                questionKey: {
+                  S: "testQuestionKey",
+                },
+                answer: {
+                  S: "testAnswer",
+                },
+              },
+            ],
+          },
+        },
+        {} as Context
+      );
+      expect(result).toEqual(hmrcResponse);
+    });
+  });
+
+  describe("unhappy path scenarios", () => {
+    it("it should return response text when HMRC error is not JSON", async () => {
+      const hmrcResponse = "Bad request";
+      global.fetch = jest.fn();
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        text: jest.fn().mockResolvedValueOnce(hmrcResponse),
+      });
+      const submitAnswerHandler = new SubmitAnswerHandler();
+      const response = await submitAnswerHandler.handler(
+        {
+          nino: "good-nino",
+          parameters: {
+            url: "testUrl",
+            userAgent: "testUserAgent",
+          },
+          oAuthToken: {
+            value: "badOAuthToken",
+          },
+          questions: {
+            Items: [
+              {
+                correlationId: {
+                  S: "testCorrelationId",
+                },
+                questionKey: {
+                  S: "testQuestionKey",
+                },
+                answer: {
+                  S: "testAnswer",
+                },
+              },
+            ],
+          },
+        },
+        {} as Context
+      );
+      expect(response).toEqual(hmrcResponse);
+    });
+
+    it("it should throw on error when trying to call the API", async () => {
+      const submitAnswerHandler = new SubmitAnswerHandler();
+      await expect(
+        submitAnswerHandler.handler(
+          {
+            nino: "good-nino",
+            parameters: {
+              url: "testUrl",
+              userAgent: "testUserAgent",
+            },
+            oAuthToken: {
+              value: "badOAuthToken",
+            },
+            questions: {
+              Items: [
+                {
+                  correlationId: {
+                    S: "testCorrelationId",
+                  },
+                  questionKey: {
+                    S: "testQuestionKey",
+                  },
+                  answer: {
+                    S: "testAnswer",
+                  },
+                },
+              ],
+            },
+          },
+          {} as Context
+        )
+      ).rejects.toThrow();
+    });
   });
 });


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[P4-XXXX] PR Title` -->

## Proposed changes

### What changed
`submit-answer-handler.ts` - In error scenarios, HMRC sometimes give text as a response instead of JSON so additional error handling has been added

`submit-answer-handler.test.ts` - Added unit test definition

<!-- Describe the changes in detail - the "what"-->

### Why did it change
Test coverage
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [OJ-1959](https://govukverify.atlassian.net/browse/OJ-1959)

## Checklists

### Environment variables or secrets

<!-- Delete if changes DO include new environment variables or secrets -->

- [ ] No environment variables or secrets were added or changed

<!-- Delete if changes DO NOT include new environment variables or secrets -->

- [ ] Documented in the [README](./blob/main/README.md)
- [ ] Added to deployment repository
- [ ] Added to local startup repository

### Other considerations

- [ ] Update [README](./blob/main/README.md) with any new instructions or tasks


[OJ-1959]: https://govukverify.atlassian.net/browse/OJ-1959?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ