### PR TITLE
BAU: Added export for private APIGW

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -776,6 +776,13 @@ Resources:
       RetentionInDays: 30
 
 Outputs:
+  PrivateApiGatewayId:
+    Description: "API GatewayID of the private Address CRI API"
+    Value:
+      !If [IsNotDevEnvironment, !Ref PrivateKbvHmrcApi, !Ref DevOnlyKbvHmrcApi]
+    Export:
+      Name: !Sub ${AWS::StackName}-PrivateApiGatewayId
+
   CreateAuthCodeFunction:
     Description: "Create Authorization Code Function ARN"
     Value: !GetAtt CreateAuthCodeFunction.Arn


### PR DESCRIPTION
## Proposed changes

### What changed
`template.yaml`

### Why did it change
The private API gateway ID needs to be exported because this is required for the HMRC KBV frontend to know of the private API.


