### PR TITLE
BAU: Use the latest shared GitHub Actions

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -12,7 +12,7 @@ jobs:
       cancel-in-progress: true
     steps:
       - name: Run pre-commit
-        uses: govuk-one-login/github-actions/code-quality/run-pre-commit@d233e5a687f5c816b19bb25991d5709658b29ebc
+        uses: govuk-one-login/github-actions/code-quality/run-pre-commit@cd7d35dde348251237efbbaee5345e95adef0321
         with:
           all-files: true
 

--- a/.github/workflows/clean-up-deployments.yml
+++ b/.github/workflows/clean-up-deployments.yml
@@ -26,7 +26,7 @@ jobs:
           aws-region: eu-west-2
 
       - name: Get stale preview stacks
-        uses: govuk-one-login/github-actions/sam/get-stale-stacks@d233e5a687f5c816b19bb25991d5709658b29ebc
+        uses: govuk-one-login/github-actions/sam/get-stale-stacks@cd7d35dde348251237efbbaee5345e95adef0321
         with:
           threshold-days: 14
           stack-name-filter: preview-kbv-hmrc-api
@@ -38,7 +38,7 @@ jobs:
 
       - name: Delete stacks
         if: ${{ env.STACKS != null }}
-        uses: govuk-one-login/github-actions/sam/delete-stacks@d233e5a687f5c816b19bb25991d5709658b29ebc
+        uses: govuk-one-login/github-actions/sam/delete-stacks@cd7d35dde348251237efbbaee5345e95adef0321
         with:
           stack-names: ${{ env.STACKS }}
           verbose: true

--- a/.github/workflows/delete-deployment.yml
+++ b/.github/workflows/delete-deployment.yml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Get stack name
-        uses: govuk-one-login/github-actions/beautify-branch-name@d233e5a687f5c816b19bb25991d5709658b29ebc
+        uses: govuk-one-login/github-actions/beautify-branch-name@cd7d35dde348251237efbbaee5345e95adef0321
         id: get-stack-name
         with:
           usage: Stack name
@@ -29,7 +29,7 @@ jobs:
           verbose: false
 
       - name: Delete stack
-        uses: govuk-one-login/github-actions/sam/delete-stacks@d233e5a687f5c816b19bb25991d5709658b29ebc
+        uses: govuk-one-login/github-actions/sam/delete-stacks@cd7d35dde348251237efbbaee5345e95adef0321
         with:
           stack-names: ${{ steps.get-stack-name.outputs.pretty-branch-name }}
           aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -20,15 +20,12 @@ jobs:
     name: Build SAM app
     runs-on: ubuntu-latest
     permissions: {}
-    outputs:
-      artifact-name: ${{ steps.build.outputs.artifact-name }}
     steps:
       - name: Build SAM application
-        uses: govuk-one-login/github-actions/sam/build-application@d233e5a687f5c816b19bb25991d5709658b29ebc
+        uses: govuk-one-login/github-actions/sam/build-application@cd7d35dde348251237efbbaee5345e95adef0321
         id: build
         with:
           template: infrastructure/template.yaml
-          artifact-name: kbv-hmrc-api
           cache-key: kbv-hmrc-api
           pull-repository: true
 
@@ -47,17 +44,16 @@ jobs:
       stack-name: ${{ steps.deploy.outputs.stack-name }}
     steps:
       - name: Deploy stack
-        uses: govuk-one-login/github-actions/sam/deploy-stack@d233e5a687f5c816b19bb25991d5709658b29ebc
+        uses: govuk-one-login/github-actions/sam/deploy-stack@cd7d35dde348251237efbbaee5345e95adef0321
         id: deploy
         with:
           sam-deployment-bucket: ${{ vars.DEPLOYMENT_ARTIFACTS_BUCKET }}
           aws-role-arn: ${{ vars.DEPLOYMENT_ROLE_ARN }}
           stack-name-prefix: preview-kbv-hmrc-api
+          cache-key: kbv-hmrc-api
           s3-prefix: preview
           pull-repository: true
           delete-failed-stack: true
-          artifact-path: .aws-sam/build
-          artifact-name: ${{ needs.build.outputs.artifact-name }}
           tags: |
             cri:component=ipv-cri-kbv-hmrc-api
             cri:stack-type=preview

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -44,4 +44,4 @@ jobs:
         with:
           name: ${{ inputs.coverage-artifact }}
           retention-days: 3
-          path: coverage
+          path: coverage/lcov.info

--- a/.github/workflows/scan-repo.yml
+++ b/.github/workflows/scan-repo.yml
@@ -26,8 +26,8 @@ jobs:
     needs: unit-tests
     runs-on: ubuntu-latest
     steps:
-      - name: Run a SonarCloud scan
-        uses: govuk-one-login/github-actions/code-quality/sonarcloud@d233e5a687f5c816b19bb25991d5709658b29ebc
+      - name: Run SonarCloud scan
+        uses: govuk-one-login/github-actions/code-quality/sonarcloud@cd7d35dde348251237efbbaee5345e95adef0321
         with:
           coverage-artifact: ${{ needs.unit-tests.outputs.coverage-artifact }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -39,7 +39,7 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - name: Run a CodeQL scan
-        uses: govuk-one-login/github-actions/code-quality/codeql@d233e5a687f5c816b19bb25991d5709658b29ebc
+      - name: Run CodeQL scan
+        uses: govuk-one-login/github-actions/code-quality/codeql@cd7d35dde348251237efbbaee5345e95adef0321
         with:
           languages: javascript-typescript

--- a/integration-tests/package.json
+++ b/integration-tests/package.json
@@ -11,6 +11,7 @@
     "test:all": "npm run unit:all --",
     "test:aws": "npm run unit:aws --",
     "test:mocked": "npm run unit:mocked --",
+    "deploy": "../deploy.sh",
     "compile": "tsc"
   },
   "author": "alphagov",


### PR DESCRIPTION
Use the SAM build cache instead of the artifact to improve performance.

Only archive SonarCloud test coverage report file