### PR TITLE
BAU: Minor fixes to jest config and deployment script

### DIFF
--- a/.github/refresh-hmrc-token.sh
+++ b/.github/refresh-hmrc-token.sh
@@ -1,0 +1,34 @@
+set -eu
+
+expiry_parameter=$(aws ssm describe-parameters \
+  --parameter-filters Key=Name,Option=Contains,Values=BearerTokenExpiry \
+  --query "Parameters[0].Name" --output text)
+
+expiry_ms=$(aws ssm get-parameter --name "$expiry_parameter" --query "Parameter.Value" --output text)
+refresh_ms=$(("$expiry_ms" - 20 * 60 * 1000))
+current_ms=$(($(date +%s) * 1000))
+
+if [[ $current_ms -lt $refresh_ms ]]; then
+  remaining_ms=$(("$expiry_ms" - "$current_ms"))
+  echo "Token expires in $(("$remaining_ms" / 1000 / 60)) minutes"
+  exit
+fi
+
+echo "Refreshing token..."
+
+otg_arn=$(aws stepfunctions list-state-machines \
+  --query "stateMachines[?contains(name, 'OAuthTokenGenerator')] | [0].stateMachineArn" \
+  --output text)
+
+execution_arn=$(aws stepfunctions start-execution --state-machine-arn "$otg_arn" | jq --raw-output .executionArn)
+
+echo "Waiting for state machine execution..."
+while [[ ${status:-RUNNING} == RUNNING ]]; do
+  status=$(aws stepfunctions describe-execution --execution-arn "$execution_arn" --query status --output text)
+  sleep 1
+done
+
+[[ $status == SUCCEEDED ]] && echo "Token has been refreshed" && exit
+
+echo "Token refresh has failed"
+exit 1

--- a/.github/workflows/run-aws-tests.yml
+++ b/.github/workflows/run-aws-tests.yml
@@ -16,7 +16,6 @@ concurrency:
 
 defaults:
   run:
-    working-directory: integration-tests
     shell: bash
 
 jobs:
@@ -43,7 +42,12 @@ jobs:
           role-to-assume: ${{ vars.DEPLOYMENT_ROLE_ARN }}
           aws-region: ${{ inputs.aws-region }}
 
+      - name: Refresh HMRC OAuth token
+        run: .github/refresh-hmrc-token.sh
+        shell: bash
+
       - name: Run tests
+        working-directory: integration-tests
         env:
           AWS_REGION: ${{ inputs.aws-region }}
           STACK_NAME: ${{ inputs.stack-name }}

--- a/deploy.sh
+++ b/deploy.sh
@@ -6,7 +6,7 @@ stack_name="${1:-}"
 common_stack_name="${2:-}"
 
 if ! [[ "$stack_name" ]]; then
-  [[ $(aws whoami --query Arn --output text) =~ \/([^\/\.]+)\. ]] && user="${BASH_REMATCH[1]}" || exit
+  [[ $(aws sts get-caller-identity --query Arn --output text) =~ \/([^\/\.]+)\. ]] && user="${BASH_REMATCH[1]}" || exit
   stack_name="$user-kbv-hmrc-api"
   echo "» Using stack name '$stack_name'"
 fi

--- a/integration-tests/tests/aws/jest.config.ts
+++ b/integration-tests/tests/aws/jest.config.ts
@@ -3,5 +3,6 @@ import baseConfig from "../../jest.config";
 
 export default {
   ...baseConfig,
+  projects: [],
   displayName: "integration-tests/aws",
 } satisfies Config;

--- a/integration-tests/tests/mocked/jest.config.ts
+++ b/integration-tests/tests/mocked/jest.config.ts
@@ -3,6 +3,7 @@ import baseConfig from "../../jest.config";
 
 export default {
   ...baseConfig,
+  projects: [],
   testTimeout: 30_000,
   displayName: "integration-tests/mocked",
 } satisfies Config;


### PR DESCRIPTION
- The `whoami` alias might not be set up by default by the CLI so use the full command instead
- Fix jest config error
Fix the error `Can't find a root directory while resolving a config file path` when running an individual test rather than the whole suite.


**Automatically refresh the HMRC OAuth token for integration tests**

Run a script before each test that will check the token expiry and refresh it if there's less than 20 minutes to expiry at the time the tests run.

Job runs using the script:
- [Token is expired](https://github.com/govuk-one-login/ipv-cri-kbv-hmrc-api/actions/runs/7227082886/job/19694046431)
```
Run .github/refresh-hmrc-token.sh
Refreshing token...
Waiting for state machine execution...
Token has been refreshed
```
- [Token is valid](https://github.com/govuk-one-login/ipv-cri-kbv-hmrc-api/actions/runs/7227082886/job/19694098974)
```
Run .github/refresh-hmrc-token.sh
Token expires in 237 minutes
```