### PR TITLE
LIME-1076: Moving repo permissions and deployment from Orange to Lime

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -17,7 +17,7 @@
 <!-- List any related ADRs or RFCs -->
 <!-- Delete/copy as appropriate -->
 
-- [OJ-XXXX](https://govukverify.atlassian.net/browse/OJ-XXXX)
+- [LIME-XXXX](https://govukverify.atlassian.net/browse/LIME-XXXX)
 
 ## Checklists
 

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -57,7 +57,7 @@ jobs:
           tags: |
             cri:component=ipv-cri-kbv-hmrc-api
             cri:stack-type=preview
-            cri:application=Orange
+            cri:application=Lime
             cri:deployment-source=github-actions
           parameters: |
             Environment=dev

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @govuk-one-login/cri-orange-team @govuk-one-login/cri-orange-admins @govuk-one-login/cri-lime-team-leads @govuk-one-login/identity-sre # Team ownership with break-glass overrides
+* @govuk-one-login/cri-orange-team @govuk-one-login/cri-orange-admins @govuk-one-login/cri-lime-team-leads @govuk-one-login/cri-lime-team @govuk-one-login/cri-lime-team-leads @govuk-one-login/identity-sre # Team ownership with break-glass overrides

--- a/deploy.sh
+++ b/deploy.sh
@@ -11,7 +11,6 @@ if ! [[ "$stack_name" ]]; then
   echo "» Using stack name '$stack_name'"
 fi
 
-sam validate -t infrastructure/template.yaml
 sam validate -t infrastructure/template.yaml --lint
 
 sam build -t infrastructure/template.yaml --cached --parallel
@@ -26,7 +25,7 @@ sam deploy --stack-name "$stack_name" \
   --tags \
   cri:component=ipv-cri-kbv-hmrc-api \
   cri:stack-type=dev \
-  cri:application=Orange \
+  cri:application=Lime \
   cri:deployment-source=manual \
   --parameter-overrides \
   ${common_stack_name:+CommonStackName=$common_stack_name} \


### PR DESCRIPTION
## Proposed changes

### What changed

Updated permissions, PR templates and Deployments to align to Lime

### Why did it change

To simplify the management of the repo by the Lime team

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->
<!-- List any related ADRs or RFCs -->
<!-- Delete/copy as appropriate -->

- [LIME-1076](https://govukverify.atlassian.net/browse/LIME-1076)
