### PR TITLE
LIME-1080 - Update endpoint that will get questions from HMRC

### DIFF
--- a/.github/refresh-hmrc-token.sh
+++ b/.github/refresh-hmrc-token.sh
@@ -5,12 +5,12 @@ expiry_parameter=$(aws ssm describe-parameters \
   --query "Parameters[0].Name" --output text)
 
 expiry_ms=$(aws ssm get-parameter --name "$expiry_parameter" --query "Parameter.Value" --output text)
-refresh_ms=$(("$expiry_ms" - 20 * 60 * 1000))
+refresh_ms=$(($expiry_ms - (20 * 60 * 1000)))
 current_ms=$(($(date +%s) * 1000))
 
 if [[ $current_ms -lt $refresh_ms ]]; then
-  remaining_ms=$(("$expiry_ms" - "$current_ms"))
-  echo "Token expires in $(("$remaining_ms" / 1000 / 60)) minutes"
+  remaining_ms=$(($expiry_ms - $current_ms))
+  echo "Token expires in $(($remaining_ms / 1000 / 60)) minutes"
   exit
 fi
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,38 @@
+# Digital Identity HMRC KBV Credential Issuer
+
+HMRC KBV Credential Issuer
+
+## Build
+
+Build with `./gradlew`
+
+## Deploy
+
+### Prerequisites
+
+See onboarding guide for instructions on how to setup the following command line interfaces (CLI)
+
+- aws cli
+- aws-vault
+- sam cli
+
+### Deploy to dev account
+
+Any time you wish to deploy, run:
+
+`aws-vault exec hmrc-kbv-dev -- ./deploy.sh <unique-stack-name>`
+
+### Delete stack from dev account
+
+> The stack name _must_ be unique to you and created by you in the deploy stage above.
+> Type `yes` when prompted to delete the stack and the folders in S3 bucket
+
+The command to run is:
+
+`aws-vault exec hmrc-kbv-dev -- sam delete --config-env dev --stack-name <unique-stack-name>`
+
+## Running Unit Tests
+
+## Running Integration Tests
+
+`AWS_REGION="eu-west-2" STACK_NAME="<unique-stack-name>" aws-vault exec hmrc-kbv-dev npm run unit:aws`

--- a/deploy.sh
+++ b/deploy.sh
@@ -11,6 +11,11 @@ if ! [[ "$stack_name" ]]; then
   echo "» Using stack name '$stack_name'"
 fi
 
+if [ -z "$common_stack_name" ]
+then
+  common_stack_name="hmrc-kbv-common-cri-api-local"
+fi
+
 sam validate -t infrastructure/template.yaml --lint
 
 sam build -t infrastructure/template.yaml --cached --parallel
@@ -28,5 +33,5 @@ sam deploy --stack-name "$stack_name" \
   cri:application=Lime \
   cri:deployment-source=manual \
   --parameter-overrides \
-  ${common_stack_name:+CommonStackName=$common_stack_name} \
+  CommonStackName=$common_stack_name \
   Environment=dev

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -13,6 +13,14 @@ Parameters:
     Type: String
     Default: dev
     AllowedValues: [dev, build, staging, integration, production]
+  AuditEventNamePrefix:
+    Description: "The audit event name prefix"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/common-cri-parameters/AuditEventNamePrefix"
+  CriIdentifier:
+    Description: "The unique credential issuer identifier"
+    Type: AWS::SSM::Parameter::Value<String>
+    Default: "/common-cri-parameters/CriIdentifier"
   CommonStackName:
     Type: String
     Default: common-cri-api
@@ -71,6 +79,11 @@ Globals:
     Environment:
       Variables:
         NODE_OPTIONS: --enable-source-maps
+        AWS_STACK_NAME: !Sub ${AWS::StackName}
+        POWERTOOLS_LOG_LEVEL: INFO
+        SQS_AUDIT_EVENT_QUEUE_URL: !ImportValue AuditEventQueueUrl
+        SQS_AUDIT_EVENT_PREFIX: !Ref AuditEventNamePrefix
+        POWERTOOLS_METRICS_NAMESPACE: !Ref CriIdentifier
         AWS_LAMBDA_EXEC_WRAPPER: /opt/dynatrace
         DT_OPEN_TELEMETRY_ENABLE_INTEGRATION: true
         DT_CONNECTION_AUTH_TOKEN: !Sub
@@ -317,6 +330,11 @@ Resources:
         Sourcemap: true
     Properties:
       Handler: lambdas/fetch-questions/src/fetch-questions-handler.lambdaHandler
+      FunctionName: !Sub "${AWS::StackName}-fetchquestions"
+      Environment:
+        Variables:
+          POWERTOOLS_SERVICE_NAME: !Sub "${CriIdentifier}-fetchquestions"
+      Timeout: 15
       CodeSigningConfigArn:
         !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
 

--- a/integration-tests/tests/aws/get-ivq-questions/get-ivq-questions-happy.test.ts
+++ b/integration-tests/tests/aws/get-ivq-questions/get-ivq-questions-happy.test.ts
@@ -2,7 +2,7 @@ import { stackOutputs } from "../resources/cloudformation-helper";
 import { clearItems, populateTable } from "../resources/dynamodb-helper";
 import { executeStepFunction } from "../resources/stepfunction-helper";
 
-jest.setTimeout(10_000);
+jest.setTimeout(20_000);
 
 describe("get-ivq-questions-happy", () => {
   const stateMachineInput = {
@@ -94,15 +94,8 @@ describe("get-ivq-questions-happy", () => {
         output.IvqQuestionStateMachineArn
       )) as any;
       const result = JSON.parse(startExecutionResult.output);
-      const fetchedQuestion = result.Payload.questions;
-      for (let counter = 0; counter < testQuestions.length; counter++) {
-        expect(testQuestions[counter].questionKey).toBe(
-          fetchedQuestion[counter].questionKey
-        );
-        expect(testQuestions[counter].info).toEqual(
-          fetchedQuestion[counter].info
-        );
-      }
+      const availableQuestions = result.Payload.availableQuestions;
+      expect(availableQuestions).toEqual("6");
     });
     it("should not fetch questions from HMRC when there are questions in DB", async () => {
       for (const question of testQuestions) {
@@ -113,7 +106,7 @@ describe("get-ivq-questions-happy", () => {
         output.IvqQuestionStateMachineArn
       )) as any;
       const result = JSON.parse(startExecutionResult.output);
-      const loadedQuestion: Array<String> = result.loadedQuestions.Items;
+      const loadedQuestion: Array<string> = result.loadedQuestions.Items;
       for (let counter = 0; counter < testQuestions.length; counter++) {
         expect(loadedQuestion.includes(testQuestions[counter].questionKey));
         expect(loadedQuestion.includes(testQuestions[counter].info.months));

--- a/integration-tests/tests/aws/get-question/get-question-happy.test.ts
+++ b/integration-tests/tests/aws/get-question/get-question-happy.test.ts
@@ -23,7 +23,7 @@ describe("get-question", () => {
     }
   };
 
-  let testQuestions = [
+  const testQuestions = [
     {
       sessionId: stateMachineInput.sessionId,
       answered: "false",
@@ -117,7 +117,7 @@ describe("get-question", () => {
         );
       });
       it("should return 204 when there are no unanswered left", async () => {
-        for (let question of testQuestions) {
+        for (const question of testQuestions) {
           question.answered = "true";
           await populateTable(question, output.QuestionsTable);
         }

--- a/integration-tests/tests/aws/post-answers/post-answers-happy.test.ts
+++ b/integration-tests/tests/aws/post-answers/post-answers-happy.test.ts
@@ -28,7 +28,7 @@ describe("post-answers-happy", () => {
     });
   };
 
-  let testQuestions = [
+  const testQuestions = [
     {
       sessionId: stateMachineInput.sessionId,
       answered: "false",

--- a/integration-tests/tests/aws/post-ivq-answers/post-ivq-answers-happy.test.ts
+++ b/integration-tests/tests/aws/post-ivq-answers/post-ivq-answers-happy.test.ts
@@ -27,7 +27,7 @@ describe("post-ivq-answers", () => {
     });
   };
 
-  let testQuestions = [
+  const testQuestions = [
     {
       sessionId: stateMachineInput.sessionId,
       answered: "true",

--- a/lambdas/fetch-questions/package.json
+++ b/lambdas/fetch-questions/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "unit": "jest --silent",
+    "unit": "jest --verbose",
     "test": "npm run unit --",
     "test:coverage": "npm run unit -- --coverage",
     "deploy": "../../deploy.sh",

--- a/lambdas/fetch-questions/src/services/questions-retrieval-service.ts
+++ b/lambdas/fetch-questions/src/services/questions-retrieval-service.ts
@@ -1,0 +1,214 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+import { MetricUnits } from "@aws-lambda-powertools/metrics";
+import { QuestionsResult, Question } from "../types/questions-result-types";
+import {
+  HTTPMetric,
+  ResponseValidity,
+} from "../../../../lib/src/MetricTypes/http-service-metrics";
+
+import { Classification } from "../../../../lib/src/MetricTypes/metric-classifications";
+import { MetricsProbe } from "../../../../lib/src/Service/metrics-probe";
+
+enum QuestionServiceMetrics {
+  ResponseQuestionKeyCount = "ResponseQuestionKeyCount",
+  MappedQuestionKeyCount = "MappedQuestionKeyCount",
+}
+
+const ServiceName: string = "QuestionsRetrievalService";
+const logger = new Logger({ serviceName: `${ServiceName}` });
+
+export class QuestionsRetrievalService {
+  metricsProbe: MetricsProbe;
+
+  constructor(metricProbe: MetricsProbe) {
+    this.metricsProbe = metricProbe;
+  }
+
+  public async retrieveQuestions(event: any): Promise<QuestionsResult> {
+    return await this.performAPIRequest(event);
+  }
+
+  private async performAPIRequest(event: any): Promise<QuestionsResult> {
+    logger.info("Performing API Request");
+
+    // Response Latency (Start)
+    const start: number = Date.now();
+
+    return await fetch(event.parameters.url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "User-Agent": event.parameters.userAgent,
+        Authorization: "Bearer " + event.bearerToken.value,
+      },
+      body: JSON.stringify({
+        nino: event.nino,
+      }),
+    })
+      .then(async (response) => {
+        // Happy Path Response Latency
+        const latency: number = this.captureResponseLatency(start);
+
+        logger.info(
+          `API Response Status Code: ${response.status}, Latency : ${latency}`
+        );
+
+        // Response Status code
+        this.metricsProbe.captureServiceMetric(
+          HTTPMetric.HTTPStatusCode,
+          Classification.HTTP,
+          ServiceName,
+          MetricUnits.Count,
+          response.status
+        );
+
+        switch (response.status) {
+          case 200: {
+            return this.retrieveJSONResponse(response)
+              .then((jsonResponse) => {
+                let questionsResult: QuestionsResult;
+                try {
+                  questionsResult = this.mapToQuestionsResult(jsonResponse);
+                } catch (error: any) {
+                  const errorText: string = error.message;
+
+                  throw new Error(
+                    `Unabled to map QuestionsResult from json in response : ${errorText}`
+                  );
+                }
+
+                this.metricsProbe.captureServiceMetric(
+                  HTTPMetric.ResponseValidity,
+                  Classification.HTTP,
+                  ServiceName,
+                  MetricUnits.Count,
+                  ResponseValidity.Valid
+                );
+
+                return questionsResult;
+              })
+              .catch((error: Error) => {
+                const subError: string = error.message;
+
+                const errorText: string = `Unable to parse json from response ${subError}`;
+
+                throw new Error(errorText);
+              });
+          }
+          case 401: {
+            // oauth token rejected
+            const errorText: string = await Promise.resolve(response.text());
+
+            throw new Error(
+              `API Request Failed due to Credentials being rejected - ${errorText}`
+            );
+          }
+          default: {
+            // any other status code
+            const errorText: string = await Promise.resolve(response.text());
+
+            throw new Error(`Unexpected Response - ${errorText}`);
+          }
+        }
+      })
+      .catch((error: Error) => {
+        // All errors caught in this top level catch
+        this.metricsProbe.captureServiceMetric(
+          HTTPMetric.ResponseValidity,
+          Classification.HTTP,
+          ServiceName,
+          MetricUnits.Count,
+          ResponseValidity.Invalid
+        );
+
+        // Error Path Response Latency
+        const latency: number = this.captureResponseLatency(start);
+
+        // any other status code
+        const errorText: string = `API Request Failed : ${error.message}`;
+
+        logger.error(`$errorText, , Latency : ${latency}`);
+
+        throw new Error(errorText);
+      });
+  }
+
+  private mapToQuestionsResult(json: any): QuestionsResult {
+    logger.info(`Mapping QuestionsResult`);
+
+    const correlationId = json.correlationId;
+    const responseQuestions = json.questions;
+    const mappedQuestions: Question[] = [];
+
+    responseQuestions.forEach(
+      (question: {
+        [info: string]: { taxYearCurrent: string; taxYearPrevious: string };
+        questionKey: any;
+      }) => {
+        const questionKey: string = question.questionKey;
+        logger.debug(`question : ${questionKey}`);
+
+        let taxYearCurrent: string | undefined = undefined;
+        let taxYearPrevious: string | undefined = undefined;
+
+        if (Object.prototype.hasOwnProperty.call(question, "info")) {
+          taxYearCurrent = question["info"].taxYearCurrent;
+          taxYearPrevious = question["info"].taxYearPrevious;
+        }
+
+        logger.debug(`info taxYearCurrent: ${taxYearCurrent}`);
+        logger.debug(`info taxYearPrevious: ${taxYearPrevious}`);
+
+        mappedQuestions.push(
+          new Question(questionKey, taxYearCurrent, taxYearPrevious)
+        );
+      }
+    );
+
+    // capture both the returned and mapped count (question filtering and metrics for keys/categories to be added)
+    this.metricsProbe.captureServiceMetric(
+      QuestionServiceMetrics.ResponseQuestionKeyCount,
+      Classification.SERVICE_SPECIFIC,
+      ServiceName,
+      MetricUnits.Count,
+      responseQuestions.length
+    );
+
+    this.metricsProbe.captureServiceMetric(
+      QuestionServiceMetrics.MappedQuestionKeyCount,
+      Classification.SERVICE_SPECIFIC,
+      ServiceName,
+      MetricUnits.Count,
+      responseQuestions.length
+    );
+
+    logger.info(`Mapped QuestionsResult`);
+    return new QuestionsResult(correlationId, mappedQuestions);
+  }
+
+  private async retrieveJSONResponse(response: Response): Promise<any> {
+    const contentType = response.headers.get("content-type");
+
+    if (contentType?.includes("application/json")) {
+      return await response.json();
+    } else {
+      // Not logged as caught in caller
+      const errorText: string = `unexpected content type : ${contentType}`;
+      throw new Error(errorText);
+    }
+  }
+
+  private captureResponseLatency(start: number): number {
+    // Response Latency (End)
+    const latency: number = Date.now() - start;
+    this.metricsProbe.captureServiceMetric(
+      HTTPMetric.ResponseLatency,
+      Classification.HTTP,
+      ServiceName,
+      MetricUnits.Count,
+      latency
+    );
+
+    return latency;
+  }
+}

--- a/lambdas/fetch-questions/src/types/questions-result-types.ts
+++ b/lambdas/fetch-questions/src/types/questions-result-types.ts
@@ -1,0 +1,44 @@
+export class Info {
+  readonly taxYearCurrent: string | undefined;
+  readonly taxYearPrevious: string | undefined;
+
+  constructor(taxYearCurrent: string, taxYearPrevious: string | undefined) {
+    this.taxYearCurrent = taxYearCurrent;
+    this.taxYearPrevious = taxYearPrevious;
+  }
+}
+
+export class Question {
+  readonly questionKey: string;
+  readonly info: Info | undefined;
+
+  constructor(
+    questionKey: string,
+    taxYearCurrent: string | undefined,
+    taxYearPrevious: string | undefined
+  ) {
+    this.questionKey = questionKey;
+
+    this.info = taxYearCurrent
+      ? new Info(taxYearCurrent, taxYearPrevious)
+      : undefined;
+  }
+}
+
+export class QuestionsResult {
+  readonly correlationId: string;
+  readonly questions: Question[];
+
+  constructor(correlationId: string, questions: Question[]) {
+    this.correlationId = correlationId;
+    this.questions = questions;
+  }
+
+  getCorrelationId(): string {
+    return this.correlationId;
+  }
+
+  getQuestionCount(): number {
+    return this.questions.length;
+  }
+}

--- a/lambdas/fetch-questions/tests/fetch-questions-handler.test.ts
+++ b/lambdas/fetch-questions/tests/fetch-questions-handler.test.ts
@@ -1,108 +1,146 @@
+import { MetricUnits } from "@aws-lambda-powertools/metrics";
+import { Logger } from "@aws-lambda-powertools/logger";
 import { FetchQuestionsHandler } from "../src/fetch-questions-handler";
-import { Context } from "aws-lambda";
+import { Question } from "../src/types/questions-result-types";
+import { QuestionsRetrievalService } from "../src/services/questions-retrieval-service";
+import { QuestionsResult } from "../src/types/questions-result-types";
+import { MetricsProbe } from "../src/../../../lib/src/Service/metrics-probe";
 
-const smInput = {
-  parameters: {
-    url: "dummyUrl",
-    userAgent: "dummyUserAgent",
-  },
-  bearerToken: {
-    value: "dummyOAuthToken",
-  },
-  nino: "dummyNino",
-};
+import {
+  HandlerMetric,
+  CompletionStatus,
+} from "../../../lib/src/MetricTypes/handler-metric-types";
 
-describe("fetch-questions-handler", () => {
-  afterEach(() => {
+jest.mock("@aws-lambda-powertools/metrics");
+jest.mock("@aws-lambda-powertools/logger");
+jest.mock("../src/services/questions-retrieval-service");
+jest.mock("../src/../../../lib/src/Service/metrics-probe");
+
+describe("FetchQuestionsHandler", () => {
+  let fetchQuestionsHandler: FetchQuestionsHandler;
+  let mockMetricsProbe: jest.MockedObjectDeep<typeof MetricsProbe>;
+
+  let mockQuestionsRetrievalService: jest.MockedObjectDeep<
+    typeof QuestionsRetrievalService
+  >;
+  let questionsRetrievalServiceSpy: jest.SpyInstance;
+  let mockMetricsProbeSpy: jest.SpyInstance;
+
+  const mockInputEvent = {
+    parameters: {
+      url: "dummyUrl",
+      userAgent: "dummyUserAgent",
+    },
+    bearerToken: {
+      value: "dummyOAuthToken",
+    },
+    nino: "dummyNino",
+  };
+
+  beforeEach(() => {
     jest.clearAllMocks();
+
+    mockMetricsProbe = jest.mocked(MetricsProbe);
+    mockQuestionsRetrievalService = jest.mocked(QuestionsRetrievalService);
+
+    questionsRetrievalServiceSpy = jest.spyOn(
+      mockQuestionsRetrievalService.prototype,
+      "retrieveQuestions"
+    );
+
+    mockMetricsProbeSpy = jest.spyOn(
+      mockMetricsProbe.prototype,
+      "captureMetric"
+    );
+
+    fetchQuestionsHandler = new FetchQuestionsHandler(
+      mockMetricsProbe.prototype,
+      mockQuestionsRetrievalService.prototype
+    );
   });
 
   describe("Success Scenarios", () => {
-    it("should return a set of questions for a valid nino", async () => {
-      global.fetch = jest.fn().mockImplementation(() => {
-        return new Promise((resolve, _reject) => {
-          resolve({
-            json: () => {
-              return {
-                correlationId: "dummyCorrelationId",
-                questions: [
-                  {
-                    questionKey: "dummyQuestionKey",
-                    info: {},
-                  },
-                  {
-                    questionKey: "dummyQuestionKey1",
-                    info: {
-                      dummyChoice: "dummyChoice",
-                    },
-                  },
-                ],
-              };
-            },
-          });
-        });
-      });
-    });
+    it.each([
+      [[], 0], // Zero questions
+      [[new Question("TestKey1", undefined, undefined)], 1],
+      [
+        [
+          new Question("TestKey1", undefined, undefined),
+          new Question("TestKey2", "2021/2022", "2020/2021"),
+        ],
+        2,
+      ],
+      [
+        [
+          new Question("TestKey1", undefined, undefined),
+          new Question("TestKey2", "2021/2022", "2020/2021"),
+          new Question("TestKey3", undefined, undefined),
+        ],
+        3,
+      ],
+    ])(
+      "should return a count of questions for a valid nino when questions are returned",
+      async (questions: Question[], expectedQuestionCount: number) => {
+        const correlationId: string = "test-correlsation-id";
+
+        const mockQuestionsRetrievalServiceResponse = new QuestionsResult(
+          correlationId,
+          questions
+        );
+
+        questionsRetrievalServiceSpy.mockResolvedValue(
+          mockQuestionsRetrievalServiceResponse
+        );
+
+        const lambdaResponse = await fetchQuestionsHandler.handler(
+          mockInputEvent,
+          undefined
+        );
+
+        expect(questionsRetrievalServiceSpy).toHaveBeenCalledWith(
+          mockInputEvent
+        );
+
+        expect(mockMetricsProbeSpy).toHaveBeenCalledWith(
+          HandlerMetric.CompletionStatus,
+          MetricUnits.Count,
+          CompletionStatus.OK
+        );
+
+        const expectedResponse = {
+          availableQuestions: `${expectedQuestionCount}`,
+        };
+        expect(lambdaResponse).toEqual(expectedResponse);
+      }
+    );
   });
 
   describe("Failure Scenarios", () => {
-    it("Default values", async () => {
-      const fetchQuestionsHandler = new FetchQuestionsHandler();
-      const result = await fetchQuestionsHandler.handler(
-        smInput,
-        {} as Context
+    it("should return an error if there is an issue during question retrieval ", async () => {
+      questionsRetrievalServiceSpy.mockImplementation(() => {
+        const testErrorMessage: string = "An error occured";
+        throw new Error(testErrorMessage);
+      });
+
+      const lambdaResponse = await fetchQuestionsHandler.handler(
+        mockInputEvent,
+        undefined
       );
 
-      expect(result).toEqual({
-        correlationId: "dummyCorrelationId",
-        questions: [
-          {
-            questionKey: "dummyQuestionKey",
-            info: {},
-          },
-          {
-            questionKey: "dummyQuestionKey1",
-            info: {
-              dummyChoice: "dummyChoice",
-            },
-          },
-        ],
-      });
-    });
+      expect(questionsRetrievalServiceSpy).toHaveBeenCalledWith(mockInputEvent);
 
-    it("should throw an error when HMRC returns no questions", async () => {
-      global.fetch = jest.fn().mockImplementation(() => {
-        return new Promise((resolve, _reject) => {
-          resolve({
-            json: () => {
-              return {
-                correlationId: "dummyCorrelationId",
-                questions: [],
-              };
-            },
-          });
-        });
-      });
+      expect(mockMetricsProbeSpy).toHaveBeenCalledWith(
+        HandlerMetric.CompletionStatus,
+        MetricUnits.Count,
+        CompletionStatus.ERROR
+      );
 
-      await expect(() =>
-        new FetchQuestionsHandler().handler(smInput, {} as Context)
-      ).rejects.toThrow("No questions returned");
-    });
+      const lambdaName = FetchQuestionsHandler.name;
+      const errorText: string = "An error occured";
+      const errorMessage = `${lambdaName} : ${errorText}`;
+      const expectedResponse = { error: errorMessage };
 
-    it("should throw an error when HMRC does not return valid JSON", async () => {
-      global.fetch = jest.fn().mockImplementation(() => {
-        return new Promise((resolve, _reject) => {
-          resolve({
-            text: () => {
-              return "dummyText";
-            },
-          });
-        });
-      });
-
-      await expect(() =>
-        new FetchQuestionsHandler().handler(smInput, {} as Context)
-      ).rejects.toThrow("dummyText");
+      expect(lambdaResponse).toEqual(expectedResponse);
     });
   });
 });

--- a/lambdas/fetch-questions/tests/services/questions-retrieval-service.test.ts
+++ b/lambdas/fetch-questions/tests/services/questions-retrieval-service.test.ts
@@ -1,0 +1,335 @@
+import { Logger } from "@aws-lambda-powertools/logger";
+import { MetricUnits } from "@aws-lambda-powertools/metrics";
+import { QuestionsResult } from "../../src/types/questions-result-types";
+
+import {
+  HTTPMetric,
+  ResponseValidity,
+} from "../../../../lib/src/MetricTypes/http-service-metrics";
+
+import { QuestionsRetrievalService } from "../../src/services/questions-retrieval-service";
+import { MetricsProbe } from "../../../../lib/src/Service/metrics-probe";
+import { Classification } from "../../../../lib/src/MetricTypes/metric-classifications";
+
+enum QuestionServiceMetrics {
+  ResponseQuestionKeyCount = "ResponseQuestionKeyCount",
+  MappedQuestionKeyCount = "MappedQuestionKeyCount",
+}
+
+jest.mock("@aws-lambda-powertools/metrics");
+jest.mock("../../../../lib/src/Service/metrics-probe");
+jest.mock("node-fetch");
+
+describe("QuestionsRetrievalService", () => {
+  let questionsRetrievalService: QuestionsRetrievalService;
+  let mockMetricsProbe: jest.MockedObjectDeep<typeof MetricsProbe>;
+
+  let mockCaptureServiceMetricMetricsProbeSpy: jest.SpyInstance;
+
+  const mockInputEvent = {
+    parameters: {
+      url: "dummyUrl",
+      userAgent: "dummyUserAgent",
+    },
+    bearerToken: {
+      value: "dummyOAuthToken",
+    },
+    nino: "dummyNino",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockMetricsProbe = jest.mocked(MetricsProbe);
+
+    mockCaptureServiceMetricMetricsProbeSpy = jest.spyOn(
+      mockMetricsProbe.prototype,
+      "captureServiceMetric"
+    );
+
+    questionsRetrievalService = new QuestionsRetrievalService(
+      mockMetricsProbe.prototype
+    );
+  });
+
+  describe("Success Scenarios", () => {
+    it("should return QuestionsResult if request is successfull", async () => {
+      const apiResponse = {
+        correlationId: "test-correlationId",
+        questions: [
+          {
+            questionKey: "TEST-KEY-1",
+            info: {
+              taxYearCurrent: "2024/25",
+              taxYearPrevious: "2023/24",
+            },
+          },
+          {
+            questionKey: "TEST-KEY-2",
+          },
+          {
+            questionKey: "TEST-KEY-3",
+          },
+        ],
+      };
+
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          status: 200,
+          headers: {
+            get: jest.fn(() => {
+              return "application/json";
+            }),
+          },
+          json: () => Promise.resolve(apiResponse),
+          text: () => Promise.resolve(apiResponse),
+        })
+      ) as jest.Mock;
+
+      const questionsResult: QuestionsResult =
+        await questionsRetrievalService.retrieveQuestions(mockInputEvent);
+
+      const correlationId: string = questionsResult.getCorrelationId();
+      expect(correlationId).toEqual(apiResponse["correlationId"]);
+
+      const questionCount: number = questionsResult.getQuestionCount();
+      expect(questionCount).toEqual(apiResponse["questions"].length);
+
+      // Latency Metric
+      expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+        HTTPMetric.ResponseLatency,
+        Classification.HTTP,
+        "QuestionsRetrievalService",
+        MetricUnits.Count,
+        expect.any(Number)
+      );
+
+      // Status code
+      expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+        HTTPMetric.HTTPStatusCode,
+        Classification.HTTP,
+        "QuestionsRetrievalService",
+        MetricUnits.Count,
+        200
+      );
+
+      // Response to be valid
+      expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+        HTTPMetric.ResponseValidity,
+        Classification.HTTP,
+        "QuestionsRetrievalService",
+        MetricUnits.Count,
+        ResponseValidity.Valid
+      );
+
+      // Processed Questions to match response
+      expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+        QuestionServiceMetrics.ResponseQuestionKeyCount,
+        Classification.SERVICE_SPECIFIC,
+        "QuestionsRetrievalService",
+        MetricUnits.Count,
+        apiResponse["questions"].length
+      );
+
+      // Mapped Questions to the same as Processed (until fitering is added)
+      expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+        QuestionServiceMetrics.MappedQuestionKeyCount,
+        Classification.SERVICE_SPECIFIC,
+        "QuestionsRetrievalService",
+        MetricUnits.Count,
+        apiResponse["questions"].length
+      );
+    });
+  });
+
+  describe("Failure Scenarios", () => {
+    it("should throw an Error if API response is 200 but content-type is not application/json", async () => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          status: 200,
+          headers: {
+            get: jest.fn(() => {
+              return "application/unknown";
+            }),
+          },
+        })
+      ) as jest.Mock;
+
+      // const questionsResult: QuestionsResult =
+      //   await questionsRetrievalService.retrieveQuestions(mockInputEvent);
+
+      await expect(
+        questionsRetrievalService.retrieveQuestions(mockInputEvent)
+      ).rejects.toEqual(
+        new Error(
+          "API Request Failed : Unable to parse json from response unexpected content type : application/unknown"
+        )
+      );
+
+      // Latency Metric
+      expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+        HTTPMetric.ResponseLatency,
+        Classification.HTTP,
+        "QuestionsRetrievalService",
+        MetricUnits.Count,
+        expect.any(Number)
+      );
+
+      // Status code
+      expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+        HTTPMetric.HTTPStatusCode,
+        Classification.HTTP,
+        "QuestionsRetrievalService",
+        MetricUnits.Count,
+        200
+      );
+
+      // Response to be valid
+      expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+        HTTPMetric.ResponseValidity,
+        Classification.HTTP,
+        "QuestionsRetrievalService",
+        MetricUnits.Count,
+        ResponseValidity.Invalid
+      );
+    });
+
+    it("should throw an Error if API response is 200, content-type is application/json but response failed to be mapped to QuestionsResult", async () => {
+      const invalidJsonResponse: string = "}INVALID JSON}}{{";
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          status: 200,
+          headers: {
+            get: jest.fn(() => {
+              return "application/json";
+            }),
+          },
+          json: () => Promise.resolve(invalidJsonResponse),
+          text: () => Promise.resolve(invalidJsonResponse),
+        })
+      ) as jest.Mock;
+
+      // const questionsResult: QuestionsResult =
+      //   await questionsRetrievalService.retrieveQuestions(mockInputEvent);
+
+      await expect(
+        questionsRetrievalService.retrieveQuestions(mockInputEvent)
+      ).rejects.toEqual(
+        new Error(
+          `API Request Failed : Unable to parse json from response Unabled to map QuestionsResult from json in response : Cannot read properties of undefined (reading 'forEach')`
+        )
+      );
+
+      // Latency Metric
+      expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+        HTTPMetric.ResponseLatency,
+        Classification.HTTP,
+        "QuestionsRetrievalService",
+        MetricUnits.Count,
+        expect.any(Number)
+      );
+
+      // Status code
+      expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+        HTTPMetric.HTTPStatusCode,
+        Classification.HTTP,
+        "QuestionsRetrievalService",
+        MetricUnits.Count,
+        200
+      );
+
+      // Response to be valid
+      expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+        HTTPMetric.ResponseValidity,
+        Classification.HTTP,
+        "QuestionsRetrievalService",
+        MetricUnits.Count,
+        ResponseValidity.Invalid
+      );
+    });
+
+    it("should throw an Error if API response status code is 401", async () => {
+      const errorReponseText: string = "Unit test invalid token response body";
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          status: 401,
+          headers: {
+            get: jest.fn(() => {
+              return "application/json";
+            }),
+          },
+          // json: () => Promise.resolve(invalidJsonResponse),
+          text: () => Promise.resolve(errorReponseText),
+        })
+      ) as jest.Mock;
+
+      await expect(
+        questionsRetrievalService.retrieveQuestions(mockInputEvent)
+      ).rejects.toEqual(
+        new Error(
+          `API Request Failed : API Request Failed due to Credentials being rejected - ${errorReponseText}`
+        )
+      );
+
+      // Latency Metric
+      expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+        HTTPMetric.ResponseLatency,
+        Classification.HTTP,
+        "QuestionsRetrievalService",
+        MetricUnits.Count,
+        expect.any(Number)
+      );
+
+      // Status code
+      expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+        HTTPMetric.HTTPStatusCode,
+        Classification.HTTP,
+        "QuestionsRetrievalService",
+        MetricUnits.Count,
+        401
+      );
+    });
+
+    it("should throw an Error if API response is unexpected", async () => {
+      const errorReponseText: string = "Unit test server error response body";
+      global.fetch = jest.fn(() =>
+        Promise.resolve({
+          status: 500,
+          headers: {
+            get: jest.fn(() => {
+              return "application/json";
+            }),
+          },
+          // json: () => Promise.resolve(invalidJsonResponse),
+          text: () => Promise.resolve(errorReponseText),
+        })
+      ) as jest.Mock;
+
+      await expect(
+        questionsRetrievalService.retrieveQuestions(mockInputEvent)
+      ).rejects.toEqual(
+        new Error(
+          `API Request Failed : Unexpected Response - ${errorReponseText}`
+        )
+      );
+
+      // Latency Metric
+      expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+        HTTPMetric.ResponseLatency,
+        Classification.HTTP,
+        "QuestionsRetrievalService",
+        MetricUnits.Count,
+        expect.any(Number)
+      );
+
+      // Status code
+      expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+        HTTPMetric.HTTPStatusCode,
+        Classification.HTTP,
+        "QuestionsRetrievalService",
+        MetricUnits.Count,
+        500
+      );
+    });
+  });
+});

--- a/lambdas/fetch-questions/tsconfig.json
+++ b/lambdas/fetch-questions/tsconfig.json
@@ -15,5 +15,5 @@
     "noImplicitAny": true
   },
   "exclude": ["node_modules", "build", "coverage"],
-  "include": ["src", "tests"]
+  "include": ["src", "tests", "../../lib/src/Service/metrics-probe.ts"]
 }

--- a/lib/src/MetricTypes/handler-metric-types.ts
+++ b/lib/src/MetricTypes/handler-metric-types.ts
@@ -1,0 +1,9 @@
+// Move this enum so it can be shared
+export enum HandlerMetric {
+  CompletionStatus = "CompletionStatus",
+}
+
+export enum CompletionStatus {
+  OK = 1,
+  ERROR = 0,
+}

--- a/lib/src/MetricTypes/http-service-metrics.ts
+++ b/lib/src/MetricTypes/http-service-metrics.ts
@@ -1,0 +1,10 @@
+export enum HTTPMetric {
+  ResponseLatency = "ResponseLatency",
+  HTTPStatusCode = "HTTPStatusCode",
+  ResponseValidity = "ResponseValidity",
+}
+
+export enum ResponseValidity {
+  Valid = 1,
+  Invalid = 0,
+}

--- a/lib/src/MetricTypes/metric-classifications.ts
+++ b/lib/src/MetricTypes/metric-classifications.ts
@@ -1,0 +1,4 @@
+export enum Classification {
+  HTTP = "HTTP",
+  SERVICE_SPECIFIC = "ServiceSpecific",
+}

--- a/lib/src/Service/metrics-probe.ts
+++ b/lib/src/Service/metrics-probe.ts
@@ -1,0 +1,36 @@
+import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
+import { Classification } from "../MetricTypes/metric-classifications";
+
+// exported for attaching to cold start anotation
+export const HandlerMetricExport = new Metrics({
+  namespace: process.env.POWERTOOLS_METRICS_NAMESPACE,
+  serviceName: process.env.POWERTOOLS_SERVICE_NAME,
+});
+
+export class MetricsProbe {
+  baseMetrics: Metrics;
+
+  constructor() {
+    this.baseMetrics = HandlerMetricExport;
+  }
+
+  public captureMetric(
+    metricName: string,
+    unit: MetricUnits,
+    metricValue: number
+  ) {
+    this.baseMetrics.addMetric(metricName, unit, metricValue);
+  }
+
+  public captureServiceMetric(
+    metricName: string,
+    classification: Classification,
+    dimensionValue: string,
+    unit: MetricUnits,
+    metricValue: number
+  ) {
+    const singleMetric: Metrics = this.baseMetrics.singleMetric();
+    singleMetric.addDimension(classification, dimensionValue);
+    singleMetric.addMetric(metricName, unit, metricValue);
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
       }
     },
     "integration-tests": {
+      "name": "kbv-hmrc-test",
       "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {

--- a/step-functions/get-ivq-questions.asl.json
+++ b/step-functions/get-ivq-questions.asl.json
@@ -73,7 +73,7 @@
           "BackoffRate": 2
         }
       ],
-      "Next": "Create Question Loop Counter",
+      "Next": "Filter questions",
       "Catch": [
         {
           "ErrorEquals": ["States.ALL"],
@@ -81,115 +81,27 @@
         }
       ]
     },
-    "Create Question Loop Counter": {
-      "Comment": "Set index to zero",
-      "Type": "Pass",
-      "Parameters": {
-        "index": 0,
-        "count.$": "States.ArrayLength($.Payload.questions)"
-      },
-      "ResultPath": "$.iterator",
-      "Next": "Finished looping over all the questions?"
-    },
-    "Finished looping over all the questions?": {
-      "Comment": "Check if index is less than or equal to number of questions in the response for get ivq questions",
-      "Type": "Choice",
-      "Choices": [
-        {
-          "Variable": "$.iterator.index",
-          "NumericLessThanPath": "$.iterator.count",
-          "Next": "Get current question"
-        }
-      ],
-      "Default": "Filter questions"
-    },
-    "Get current question": {
-      "Type": "Pass",
-      "Parameters": {
-        "count.$": "$.iterator.count",
-        "currentQuestion.$": "States.ArrayGetItem($.Payload.questions, $.iterator.index)",
-        "correlationId.$": "$.Payload.correlationId",
-        "index.$": "$.iterator.index"
-      },
-      "Next": "Store question",
-      "ResultPath": "$.iterator"
-    },
-    "Store question": {
-      "Type": "Task",
-      "Resource": "arn:aws:states:::dynamodb:putItem",
-      "Parameters": {
-        "TableName": "${QuestionsTableName}",
-        "Item": {
-          "sessionId": {
-            "S.$": "$$.Execution.Input.sessionId"
-          },
-          "correlationId": {
-            "S.$": "$.iterator.correlationId"
-          },
-          "questionKey": {
-            "S.$": "$.iterator.currentQuestion.questionKey"
-          },
-          "info": {
-            "M.$": "$.iterator.currentQuestion.info"
-          },
-          "answered": {
-            "S": "false"
-          }
-        }
-      },
-      "ResultPath": "$.result",
-      "Next": "Increment index by one"
-    },
-    "Increment index by one": {
-      "Type": "Pass",
-      "Parameters": {
-        "count.$": "$.iterator.count",
-        "currentQuestion.$": "$.iterator.currentQuestion",
-        "correlationId.$": "$.iterator.correlationId",
-        "index.$": "States.MathAdd($.iterator.index, 1)"
-      },
-      "Next": "Continue looping?",
-      "ResultPath": "$.iterator"
-    },
-    "Continue looping?": {
-      "Comment": "Exit loop when index exactly equal to number of questions",
-      "Type": "Choice",
-      "Choices": [
-        {
-          "Variable": "$.iterator.index",
-          "NumericEqualsPath": "$.iterator.count",
-          "Next": "Filter questions"
-        }
-      ],
-      "Default": "Finished looping over all the questions?"
-    },
     "Filter questions": {
       "Type": "Pass",
-      "Next": "Are there sufficient questions?",
+      "Next": "Is available questions present?",
       "Comment": "TODO: Implement question filtering"
     },
     "Err: FetchQuestions threw Exception": {
       "Type": "Fail"
     },
-    "Are there sufficient questions?": {
+    "Is available questions present?": {
       "Type": "Choice",
       "Choices": [
         {
-          "Not": {
-            "Variable": "$.Payload.questions",
-            "IsPresent": true
-          },
-          "Next": "Err: Insufficient questions"
+          "Variable": "$.Payload.availableQuestions",
+          "IsPresent": true,
+          "Next": "Success"
         }
       ],
-      "Default": "Success"
+      "Default": "Err: Response Not Valid"
     },
-    "Err: Insufficient questions": {
-      "Type": "Pass",
-      "End": true,
-      "Parameters": {
-        "error": "Insufficient Questions"
-      }
+    "Err: Response Not Valid": {
+      "Type": "Fail"
     },
     "Success": {
       "Type": "Succeed"


### PR DESCRIPTION
## Proposed changes

### What changed

	- Deploy.sh
	- add fall back default common_stack_name to deploy.sh

	- Template
	- add env var AuditEventNamePrefix for audit event prefix
	- add env var CriIdentifier for power tools logging and metrics
	- add env vars for stackname
	- and env POWERTOOLS_METRICS_NAMESPACE/POWERTOOLS_SERVICE_NAME for metrics (namespace = cri, service - per lambda)
	- increase fetchquestions timeout to 15 seconds to account for stub warmup
	- add name to fetchquestions to keep lambda naming consistent between environments and simplify dashboard reuse.

	- added lib for shared objects
	- metrics probe
	- - metrics types added
	- - service metrics labled by service type

	- FetchQuestionsHandler / fetch questions lambda
	- changed unit test output to verbose
	- handler returns retrieved question count
	- - metrics added for completion ok success/failure
	- unit tests addeed

	- QuestionsRetrievalService
	- questions fetched via new QuestionsRetrievalService
	- - http metrics added for latency, response status code and response
	- - serivce metrics added for question count and mapped question count
	- QuestionsRetrievalService returns QuestionsResult in happy path only
	- - unhappy paths thrown as errors
	- unit tests addeed

	- get-ivq-questions state-machine
	- removed questions loop (now part of the lambda)
	- changed exit logic to
	- - succeeed if question count is present (0 questions not treated as an error)
	- - default/fails if not present

	- Amendments
	- - Switch to using then instead of await for fetch promises
	- - Restructure error handling chains.
	- - Move imports about declarations
        - - Remove commented code missed by linter
	- - Move latency capture to a method
	- - Move reponse retrival to a method.
	- - Allow taxYearPrevious to be undefined
	- - align integration test with current behaviour
	- - Change state type to fail when lambda returns any invalid response
	- - Updated README

State Machine Image
![stepfunctions_graph (1)](https://github.com/govuk-one-login/ipv-cri-kbv-hmrc-api/assets/105730527/0815df06-fd5a-4842-b666-2ae975afc8e9)



### Why did it change

To enable determining the count of available questions for a specfic nino with visibility of the API requests status and outcomes.

### Issue tracking

- [LIME-1080](https://govukverify.atlassian.net/browse/LIME-1080)

[LIME-1080]: https://govukverify.atlassian.net/browse/LIME-1080?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ