### PR TITLE
LIME-1161 correct fetch questions case to fetchquestions (from fetchQuestions)

### DIFF
--- a/infrastructure/private-api.yaml
+++ b/infrastructure/private-api.yaml
@@ -73,7 +73,7 @@ paths:
         contentHandling: "CONVERT_TO_TEXT"
         type: "aws_proxy"
 
-  /fetchQuestions:
+  /fetchquestions:
     post:
       description: >
         Endpoint provided by the private api gateway, triggers the retrival of questions for the NINO supplied previously in the shared claims of the JWT.


### PR DESCRIPTION
## Proposed changes

### What changed

Correct case of fetch questions endpoint to `/fetchquestions`

### Why did it change

Case was incorrectly set as `/fetchQuestions`

### Issue tracking


- [LIME-1161](https://govukverify.atlassian.net/browse/LIME-1161)

[LIME-1161]: https://govukverify.atlassian.net/browse/LIME-1161?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ