### PR TITLE
LIME-1163 Align template with passport-cri

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -12,6 +12,7 @@
 <!-- Describe the reason these changes were made - the "why" -->
 
 ### Issue tracking
+
 <!-- List any related Jira tickets or GitHub issues -->
 
 - [LIME-XXXX](https://govukverify.atlassian.net/browse/LIME-XXXX)

--- a/.github/workflows/deploy-branch.yml
+++ b/.github/workflows/deploy-branch.yml
@@ -60,4 +60,7 @@ jobs:
             cri:application=Lime
             cri:deployment-source=github-actions
           parameters: |
+            DeploymentType=pre-merge-integration
+            UseApiKey=" "
+            ParameterPrefix=ipv-cri-kbv-hmrc-api
             Environment=dev

--- a/.github/workflows/post-merge-deploy-to-build.yml
+++ b/.github/workflows/post-merge-deploy-to-build.yml
@@ -20,13 +20,8 @@ jobs:
       - name: Check out repository code
         uses: actions/checkout@v3
 
-      - name: Setup SAM
-        uses: aws-actions/setup-sam@v2
-        with:
-          version: 1.89.0
-
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.BUILD_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -34,9 +29,14 @@ jobs:
       - name: SAM Validate
         run: sam validate --region ${{ env.AWS_REGION }} -t infrastructure/template.yaml
 
+      - name: SAM build
+        run: |
+          mkdir out
+          sam build -t infrastructure/template.yaml -b out/
+
       - name: Deploy SAM app
-        uses: alphagov/di-devplatform-upload-action@v3.2
+        uses: govuk-one-login/devplatform-upload-action@v3.8
         with:
           artifact-bucket-name: "${{ secrets.BUILD_ARTIFACT_SOURCE_BUCKET_NAME }}"
           signing-profile-name: "${{ secrets.BUILD_SIGNING_PROFILE_NAME }}"
-          template-file: infrastructure/template.yaml
+          working-directory: ./out

--- a/.github/workflows/post-merge-deploy-to-dev.yml
+++ b/.github/workflows/post-merge-deploy-to-dev.yml
@@ -18,15 +18,10 @@ jobs:
       contents: read
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
-
-      - name: Setup SAM
-        uses: aws-actions/setup-sam@v2
-        with:
-          version: 1.89.0
+        uses: actions/checkout@v4
 
       - name: Assume temporary AWS role
-        uses: aws-actions/configure-aws-credentials@v2
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.DEV_GH_ACTIONS_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}
@@ -34,9 +29,14 @@ jobs:
       - name: SAM Validate
         run: sam validate --region ${{ env.AWS_REGION }} -t infrastructure/template.yaml
 
+      - name: SAM build
+        run: |
+          mkdir out
+          sam build -t infrastructure/template.yaml -b out/
+
       - name: Deploy SAM app
-        uses: alphagov/di-devplatform-upload-action@v3.2
+        uses: govuk-one-login/devplatform-upload-action@v3.8
         with:
           artifact-bucket-name: "${{ secrets.DEV_ARTIFACT_SOURCE_BUCKET_NAME }}"
           signing-profile-name: "${{ secrets.DEV_SIGNING_PROFILE_NAME }}"
-          template-file: infrastructure/template.yaml
+          working-directory: ./out

--- a/deploy.sh
+++ b/deploy.sh
@@ -2,6 +2,10 @@
 cd "$(dirname "${BASH_SOURCE[0]}")"
 set -eu
 
+RED="\033[1;31m"
+GREEN="\033[1;32m"
+NOCOLOR="\033[0m"
+
 stack_name="${1:-}"
 common_stack_name="${2:-}"
 
@@ -11,14 +15,16 @@ if ! [[ "$stack_name" ]]; then
   echo "» Using stack name '$stack_name'"
 fi
 
-if [ -z "$common_stack_name" ]
-then
+if [ -z "$common_stack_name" ]; then
   common_stack_name="hmrc-kbv-common-cri-api-local"
 fi
 
 sam validate -t infrastructure/template.yaml --lint
 
 sam build -t infrastructure/template.yaml --cached --parallel
+
+echo -e "👉 deploying ipv-cri-hmrc-kbv-api with:"
+echo -e "\tstack name: ${GREEN}$stack_name${NOCOLOR}"
 
 sam deploy --stack-name "$stack_name" \
   --no-fail-on-empty-changeset \
@@ -33,5 +39,8 @@ sam deploy --stack-name "$stack_name" \
   cri:application=Lime \
   cri:deployment-source=manual \
   --parameter-overrides \
-  CommonStackName=$common_stack_name \
-  Environment=dev
+  CommonStackName="$common_stack_name" \
+  Environment=dev \
+  ParameterPrefix="kbv-hmrc-cri-api" \
+  UseApiKey="' '" \
+  DeploymentType="not-pipeline"

--- a/infrastructure/public-api.yaml
+++ b/infrastructure/public-api.yaml
@@ -87,11 +87,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
       security:
-        - api_key:
-            Fn::If:
-              - IsDevEnvironment
-              - Ref: AWS::NoValue
-              - []
+        - api_key: []
       x-amazon-apigateway-request-validator: "Validate both"
       x-amazon-apigateway-integration:
         httpMethod: "POST"
@@ -140,11 +136,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/Error"
       security:
-        - api_key:
-            Fn::If:
-              - IsDevEnvironment
-              - Ref: AWS::NoValue
-              - []
+        - api_key: []
       x-amazon-apigateway-request-validator: "Validate both"
       x-amazon-apigateway-integration:
         httpMethod: "POST"

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -3,12 +3,18 @@ Description: Digital Identity IPV CRI KBV HMRC API
 Transform: [AWS::LanguageExtensions, AWS::Serverless-2016-10-31]
 
 Parameters:
-  BearerTokenName:
+  VpcStackName:
+    Description: >
+      The name of the stack that defines the VPC in which this container will
+      run.
     Type: String
-    Default: HMRCBearerToken
-    Description: >-
-      The name of the bearer token parameter.
-      Temporary solution to be changed once cross account behaviour implemented.
+    Default: "cri-vpc"
+  CodeSigningConfigArn:
+    Type: String
+    Default: ""
+  PermissionsBoundary:
+    Type: String
+    Default: ""
   Environment:
     Type: String
     Default: dev
@@ -25,21 +31,40 @@ Parameters:
     Type: String
     Default: common-cri-api
     Description: The name of the stack containing the common CRI lambdas/infra
-  CodeSigningConfigArn:
+  DeploymentType:
     Type: String
-    Default: ""
-  PermissionsBoundary:
+    Default: "pipeline"
+    Description: Private Api gateway resources are not be reachable in stacks deployed via pipelines, this override enables less restrictive settings for manual/pre-merge-test deployments.
+  UseApiKey:
     Type: String
-    Default: ""
+    Default: "true"
+    Description: Value used to indicate if the public api should be protected by a api key.
+  BearerTokenName:
+    Type: String
+    Default: HMRCBearerToken
+    Description: >-
+      The name of the bearer token parameter.
+      Temporary solution to be changed once cross account behaviour implemented.
 
 Conditions:
+  IsDeployedFromPipeline:
+    Fn::Equals:
+      - !Ref DeploymentType
+      - "pipeline"
+  # Don't send logs in dev to avoid overwhelming the destination with debug
+  # LogSendingEnabled: !And
+  #   - !Not [!Equals [!Ref Environment, "dev"]]
+  #   - !Condition IsDeployedFromPipeline
   EnforceCodeSigning: !Not [!Equals [!Ref CodeSigningConfigArn, ""]]
   UsePermissionsBoundary: !Not [!Equals [!Ref PermissionsBoundary, ""]]
-  IsDevEnvironment: !Equals [!Ref Environment, dev]
+  IsProdEnvironment:
+    Fn::Equals:
+      - !Ref Environment
+      - production
 
 Globals:
   Function:
-    Timeout: 3
+    Timeout: 30
     CodeUri: ..
     Runtime: nodejs18.x
     Architectures: [arm64]
@@ -112,15 +137,20 @@ Resources:
   PublicKbvHmrcApi:
     Type: AWS::Serverless::Api
     Properties:
+      Name: !Sub "${AWS::StackName}-PublicKbvHmrcApi"
       Description: Public KBV HMRC CRI API
+      StageName: !Ref Environment
+      Auth:
+        ApiKeyRequired: !Ref UseApiKey
       MethodSettings:
         - LoggingLevel: INFO
           ResourcePath: "/*"
           HttpMethod: "*"
-          DataTraceEnabled: true
+          # Disable data trace in production to avoid logging customer sensitive information
+          DataTraceEnabled: !If [IsProdEnvironment, false, true]
           MetricsEnabled: true
-          ThrottlingRateLimit: 5
-          ThrottlingBurstLimit: 10
+          ThrottlingRateLimit: 200
+          ThrottlingBurstLimit: 400
       AccessLogSetting:
         DestinationArn: !GetAtt PublicKbvHmrcApiAccessLogGroup.Arn
         Format: >-
@@ -137,8 +167,6 @@ Resources:
           "responseLength":"$context.responseLength"
           }
       TracingEnabled: true
-      Name: !Sub ${AWS::StackName}-public
-      StageName: !Ref Environment
       DefinitionBody:
         openapi: 3.0.1
         paths: # workaround to get `sam validate` to work
@@ -147,7 +175,14 @@ Resources:
         Fn::Transform:
           Name: AWS::Include
           Parameters:
-            Location: public-api.yaml
+            Location: "./public-api.yaml"
+          securitySchemes: !If
+            - IsDeployedFromPipeline
+            - api_key:
+                type: "apiKey"
+                name: "x-api-key"
+                in: "header"
+            - !Ref "AWS::NoValue"
       OpenApiVersion: 3.0.1
       EndpointConfiguration:
         Type: REGIONAL
@@ -156,20 +191,32 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/apigateway/${AWS::StackName}-${PublicKbvHmrcApi}-public-AccessLogs
-      RetentionInDays: 365
+      RetentionInDays: 30
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
+  # PublicKbvHmrcApiAccessLogGroupSubscriptionFilter:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Condition: LogSendingEnabled
+  #   Properties:
+  #     DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref PublicKbvHmrcApiAccessLogGroup
 
   PrivateKbvHmrcApi:
     Type: AWS::Serverless::Api
     Properties:
+      Name: !Sub "${AWS::StackName}-PrivateKbvHmrcApi"
       Description: Private KBV HMRC CRI API
+      StageName: !Ref Environment
       MethodSettings:
         - LoggingLevel: INFO
           ResourcePath: "/*"
           HttpMethod: "*"
-          DataTraceEnabled: true
+          # Disable data trace in production to avoid logging customer sensitive information
+          DataTraceEnabled: !If [IsProdEnvironment, false, true]
           MetricsEnabled: true
-          ThrottlingRateLimit: 5
-          ThrottlingBurstLimit: 10
+          ThrottlingRateLimit: 200
+          ThrottlingBurstLimit: 400
       AccessLogSetting:
         DestinationArn: !GetAtt PrivateKbvHmrcApiAccessLogGroup.Arn
         Format: >-
@@ -186,35 +233,53 @@ Resources:
           "responseLength":"$context.responseLength"
           }
       TracingEnabled: true
-      Name: !Sub ${AWS::StackName}-private
-      StageName: !Ref Environment
       DefinitionBody:
-        openapi: 3.0.1
+        openapi: "3.0.1" # workaround to get `sam validate` to work
         paths: # workaround to get `sam validate` to work
           /never-created:
-            options: {}
+            options: {} # workaround to get `sam validate` to work
         Fn::Transform:
           Name: AWS::Include
           Parameters:
-            Location: private-api.yaml
+            Location: "./private-api.yaml"
       OpenApiVersion: 3.0.1
       EndpointConfiguration:
-        Type: !If [IsDevEnvironment, REGIONAL, PRIVATE]
+        Type: !If [IsDeployedFromPipeline, PRIVATE, REGIONAL]
       Auth:
-        ResourcePolicy: !If
-          - IsDevEnvironment
-          - !Ref AWS::NoValue
-          - CustomStatements:
-              - Effect: Allow
-                Resource: execute-api:/*
-                Action: execute-api:Invoke
+        ResourcePolicy:
+          CustomStatements:
+            - Action: "execute-api:Invoke"
+              Effect: Allow
+              Principal: "*"
+              Resource:
+                - "execute-api:/*"
+            - !If
+              - IsDeployedFromPipeline
+              - Action: "execute-api:Invoke"
+                Effect: Deny
                 Principal: "*"
+                Resource:
+                  - "execute-api:/*"
+                Condition:
+                  StringNotEquals:
+                    aws:SourceVpce:
+                      - Fn::ImportValue: !Sub "${VpcStackName}-ExecuteApiGatewayEndpointId"
+              - !Ref AWS::NoValue
 
   PrivateKbvHmrcApiAccessLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/apigateway/${AWS::StackName}-${PrivateKbvHmrcApi}-private-AccessLogs
-      RetentionInDays: 365
+      RetentionInDays: 30
+      KmsKeyId: !GetAtt LoggingKmsKey.Arn
+
+  # PrivateKbvHmrcApiAccessLogGroupSubscriptionFilter:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Condition: LogSendingEnabled
+  #   Properties:
+  #     DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref PrivateKbvHmrcApiAccessLogGroup
 
   ExecuteStateMachineRole:
     Type: AWS::IAM::Role
@@ -327,7 +392,15 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-FetchQuestionsStateMachine-logs
-      RetentionInDays: 365
+      RetentionInDays: 30
+
+  # FetchQuestionsStateMachineLogGroupSubscriptionFilterCsls:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Condition: LogSendingEnabled
+  #   Properties:
+  #     DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref FetchQuestionsStateMachineLogGroup
 
   ####################################################################
   #                                                                  #
@@ -369,6 +442,14 @@ Resources:
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-CheckSession-state-machine-logs
       RetentionInDays: 30
+
+  # CheckSessionStateMachineLogGroupSubscriptionFilterCsls:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Condition: LogSendingEnabled
+  #   Properties:
+  #     DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref CheckSessionStateMachineLogGroup
 
   ####################################################################
   #                                                                  #
@@ -415,7 +496,15 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-GetQuestion-state-machine-logs
-      RetentionInDays: 365
+      RetentionInDays: 30
+
+  # GetQuestionStateMachineLogGroupSubscriptionFilterCsls:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Condition: LogSendingEnabled
+  #   Properties:
+  #     DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref GetQuestionStateMachineLogGroup
 
   ####################################################################
   #                                                                  #
@@ -479,7 +568,15 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-PostAnswer-state-machine-logs
-      RetentionInDays: 365
+      RetentionInDays: 30
+
+  # PostAnswerStateMachineLogGroupSubscriptionFilterCsls:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Condition: LogSendingEnabled
+  #   Properties:
+  #     DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref PostAnswerStateMachineLogGroup
 
   ####################################################################
   #                                                                  #
@@ -531,7 +628,15 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-PostIvqAnswers-state-machine-logs
-      RetentionInDays: 365
+      RetentionInDays: 30
+
+  # PostIvqAnswersStateMachineSubscriptionFilterCsls:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Condition: LogSendingEnabled
+  #   Properties:
+  #     DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref PostIvqAnswersStateMachine
 
   ####################################################################
   #                                                                  #
@@ -605,6 +710,14 @@ Resources:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-IssueCredential-state-machine-logs
       RetentionInDays: 30
 
+  # IssueCredentialStateMachineLogGroupSubscriptionFilterCsls:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Condition: LogSendingEnabled
+  #   Properties:
+  #     DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref IssueCredentialStateMachineLogGroup
+
   ####################################################################
   #                                                                  #
   # FetchQuestionsFunction                                           #
@@ -627,6 +740,12 @@ Resources:
       Timeout: 15
       CodeSigningConfigArn:
         !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
+      VpcConfig:
+        SecurityGroupIds:
+          - Fn::ImportValue: !Sub "${VpcStackName}-AWSServicesEndpointSecurityGroupId"
+        SubnetIds:
+          - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdA"
+          - Fn::ImportValue: !Sub "${VpcStackName}-ProtectedSubnetIdB"
       Policies:
         - DynamoDBWritePolicy:
             TableName: !Ref QuestionsTable
@@ -640,8 +759,16 @@ Resources:
   FetchQuestionsFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub "/aws/lambda/${FetchQuestionsFunction}"
+      LogGroupName: !Sub "/aws/lambda/${AWS::StackName}-${FetchQuestionsFunction}"
       RetentionInDays: 30
+
+  # FetchQuestionsFunctionLogGroupLogGroupSubscriptionFilterCsls:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Condition: LogSendingEnabled
+  #   Properties:
+  #     DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref FetchQuestionsFunctionLogGroup
 
   ####################################################################
   #                                                                  #
@@ -660,6 +787,20 @@ Resources:
       CodeSigningConfigArn:
         !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
 
+  TimeFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${AWS::StackName}-${TimeFunction}"
+      RetentionInDays: 30
+
+  # TimeFunctionLogGroupSubscriptionFilterCsls:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Condition: LogSendingEnabled
+  #   Properties:
+  #     DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref TimeFunctionLogGroup
+
   ####################################################################
   #                                                                  #
   # CurrentTimeFunction                                              #
@@ -676,6 +817,20 @@ Resources:
       Handler: lambdas/time/src/current-time-handler.lambdaHandler
       CodeSigningConfigArn:
         !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
+
+  CurrentTimeFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${AWS::StackName}-${CurrentTimeFunction}"
+      RetentionInDays: 30
+
+  # CurrentTimeFunctionLogGroupSubscriptionFilterCsls:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Condition: LogSendingEnabled
+  #   Properties:
+  #     DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref CurrentTimeFunctionLogGroup
 
   ####################################################################
   #                                                                  #
@@ -702,8 +857,16 @@ Resources:
   SubmitAnswerFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub "/aws/lambda/${SubmitAnswerFunction}"
+      LogGroupName: !Sub "/aws/lambda/${AWS::StackName}-${SubmitAnswerFunction}"
       RetentionInDays: 30
+
+  # SubmitAnswerFunctionLogGroupSubscriptionFilterCsls:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Condition: LogSendingEnabled
+  #   Properties:
+  #     DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref SubmitAnswerFunctionLogGroup
 
   ####################################################################
   #                                                                  #
@@ -722,6 +885,20 @@ Resources:
       CodeSigningConfigArn:
         !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
 
+  CreateAuthCodeFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${AWS::StackName}-${CreateAuthCodeFunction}"
+      RetentionInDays: 30
+
+  # CreateAuthCodeFunctionLogGroupSubscriptionFilterCsls:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Condition: LogSendingEnabled
+  #   Properties:
+  #     DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref CreateAuthCodeFunctionLogGroup
+
   ####################################################################
   #                                                                  #
   # CredentialSubjectFunction                                        #
@@ -739,6 +916,20 @@ Resources:
       CodeSigningConfigArn:
         !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
 
+  CredentialSubjectFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${AWS::StackName}-${CredentialSubjectFunction}"
+      RetentionInDays: 30
+
+  # CredentialSubjectFunctionLogGroupSubscriptionFilterCsls:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Condition: LogSendingEnabled
+  #   Properties:
+  #     DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref CredentialSubjectFunctionLogGroup
+
   ####################################################################
   #                                                                  #
   # EvidenceCheckDetailsFunction                                     #
@@ -755,6 +946,20 @@ Resources:
       Handler: lambdas/evidence-check-details/src/check-details-handler.lambdaHandler
       CodeSigningConfigArn:
         !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
+
+  EvidenceCheckDetailsFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/lambda/${AWS::StackName}-${EvidenceCheckDetailsFunction}"
+      RetentionInDays: 30
+
+  # EvidenceCheckDetailsFunctionLogGroupSubscriptionFilterCsls:
+  #   Type: AWS::Logs::SubscriptionFilter
+  #   Condition: LogSendingEnabled
+  #   Properties:
+  #     DestinationArn: "arn:aws:logs:eu-west-2:885513274347:destination:csls_cw_logs_destination_prodpython"
+  #     FilterPattern: ""
+  #     LogGroupName: !Ref EvidenceCheckDetailsFunctionLogGroup
 
   ####################################################################
   #                                                                  #
@@ -785,7 +990,53 @@ Resources:
   #                                                                  #
   ####################################################################
 
-  # TODO
+  PublicKbvHmrcApiUsagePlan:
+    Type: AWS::ApiGateway::UsagePlan
+    Condition: IsDeployedFromPipeline
+    # DependsOn:
+    #   - PublicKbvHmrcApiStage
+    Properties:
+      ApiStages:
+        - ApiId: !Ref PublicKbvHmrcApi
+          Stage: !Ref Environment
+      Quota:
+        Limit: 500000
+        Period: DAY
+      Throttle:
+        RateLimit: 200 # allowed requests per second
+        BurstLimit: 400 # requests the API can handle concurrently
+
+  PrivateKbvHmrcApiUsagePlan:
+    Type: AWS::ApiGateway::UsagePlan
+    Condition: IsDeployedFromPipeline
+    # DependsOn:
+    #   - PrivateKbvHmrcApiStage
+    Properties:
+      ApiStages:
+        - ApiId: !Ref PrivateKbvHmrcApi
+          Stage: !Ref Environment
+      Quota:
+        Limit: 500000
+        Period: DAY
+      Throttle:
+        RateLimit: 200 # allowed requests per second
+        BurstLimit: 400 # requests the API can handle concurrently
+
+  LinkUsagePlanApiKey1:
+    Condition: IsDeployedFromPipeline
+    Type: AWS::ApiGateway::UsagePlanKey
+    Properties:
+      KeyId: !ImportValue core-infrastructure-ApiKey1
+      KeyType: API_KEY
+      UsagePlanId: !Ref PublicKbvHmrcApiUsagePlan
+
+  LinkUsagePlanApiKey2:
+    Condition: IsDeployedFromPipeline
+    Type: AWS::ApiGateway::UsagePlanKey
+    Properties:
+      KeyId: !ImportValue core-infrastructure-ApiKey2
+      KeyType: API_KEY
+      UsagePlanId: !Ref PublicKbvHmrcApiUsagePlan
 
   ####################################################################
   #                                                                  #
@@ -832,6 +1083,33 @@ Resources:
       Name: !Sub /${AWS::StackName}/AnswersUrl
       Value: https://test-api.service.hmrc.gov.uk/individuals/verification/identity-verification-questions/answers
       Description: URL for HMRC /answers endpoint
+
+  LoggingKmsKey:
+    Type: AWS::KMS::Key
+    Properties:
+      EnableKeyRotation: true
+      KeyPolicy:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              AWS: !Sub "arn:aws:iam::${AWS::AccountId}:root"
+            Action:
+              - kms:*
+            Resource: "*"
+          - Effect: Allow
+            Principal:
+              Service: !Sub "logs.${AWS::Region}.amazonaws.com"
+            Action:
+              - "kms:Encrypt*"
+              - "kms:Decrypt*"
+              - "kms:ReEncrypt*"
+              - "kms:GenerateDataKey*"
+              - "kms:Describe*"
+            Resource: "*"
+            Condition:
+              ArnLike:
+                "kms:EncryptionContext:aws:logs:arn": !Sub "arn:aws:logs:${AWS::Region}:${AWS::AccountId}:*"
 
 ####################################################################
 #                                                                  #

--- a/lambdas/fetch-questions/src/services/questions-retrieval-service.ts
+++ b/lambdas/fetch-questions/src/services/questions-retrieval-service.ts
@@ -128,7 +128,7 @@ export class QuestionsRetrievalService {
         // any other status code
         const errorText: string = `API Request Failed : ${error.message}`;
 
-        logger.error(`$errorText, , Latency : ${latency}`);
+        logger.error(`${errorText}, Latency : ${latency}`);
 
         throw new Error(errorText);
       });


### PR DESCRIPTION
## Proposed changes

### What changed

	FetchQuestionsLambda
	- Placed Lambda in the protected VPC subnet
	- Minor fix to a log line

	ApiGateways
	  Public/Private
	- Enabled Usage plans in pipeline based deployments
	- Set DataTraceEnabled=false in production env
	- Aligned Rate Limits to the current values in passport/dl/fraud
	- Named the Gateways

	Public API
	- Enabled use of API Keys and require it only in request in pipeline based deployments

	Template
	- Disabled code signing if arn is not provided
	- Added LoggingKmsKey
	- Added Named log groups
	- Set retention to 30 days in all log groups
	- Added place holder csls subscription filters	+ LogSendingEnabled conditional

	Actions
	- Align preview stack deploy with expected non-pipeline values
	- Update deploy to dev, and package for build

### Why did it change

Changes are to align with PassportCRI template which has a similar vpc config and add missing configurations such as the api-key needed in higher envs and the log groups that are needed later for csls.

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1163](https://govukverify.atlassian.net/browse/LIME-1163)

[LIME-1163]: https://govukverify.atlassian.net/browse/LIME-1163?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ