### PR TITLE
LIME-1128 Correct parameters in fetch-questions/post-answer sometimes being re-ordered

### DIFF
--- a/lambdas/fetch-questions/src/services/questions-retrieval-service.ts
+++ b/lambdas/fetch-questions/src/services/questions-retrieval-service.ts
@@ -34,11 +34,11 @@ export class QuestionsRetrievalService {
     // Response Latency (Start)
     const start: number = Date.now();
 
-    return await fetch(event.parameters.url, {
+    return await fetch(event.parameters.url.value, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "User-Agent": event.parameters.userAgent,
+        "User-Agent": event.parameters.userAgent.value,
         Authorization: "Bearer " + event.bearerToken.value,
       },
       body: JSON.stringify({

--- a/lambdas/fetch-questions/tests/services/questions-retrieval-service.test.ts
+++ b/lambdas/fetch-questions/tests/services/questions-retrieval-service.test.ts
@@ -27,8 +27,8 @@ describe("QuestionsRetrievalService", () => {
 
   const mockInputEvent = {
     parameters: {
-      url: "dummyUrl",
-      userAgent: "dummyUserAgent",
+      url: { value: "dummyUrl" },
+      userAgent: { value: "dummyUserAgent" },
     },
     bearerToken: {
       value: "dummyOAuthToken",

--- a/lambdas/submit-answer/src/services/submit-answer-service.ts
+++ b/lambdas/submit-answer/src/services/submit-answer-service.ts
@@ -47,11 +47,11 @@ export class SubmitAnswerService {
     // Response Latency (Start)
     const start: number = Date.now();
 
-    return await fetch(event.parameters.url, {
+    return await fetch(event.parameters.url.value, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "User-Agent": event.parameters.userAgent,
+        "User-Agent": event.parameters.userAgent.value,
         Authorization: "Bearer " + event.bearerToken.value,
       },
       body: JSON.stringify({

--- a/package-lock.json
+++ b/package-lock.json
@@ -874,7 +874,9 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "lambdas/credential-subject": {},
+    "lambdas/credential-subject": {
+      "extraneous": true
+    },
     "lambdas/evidence-check-details": {},
     "lambdas/execute-state-machine": {
       "dependencies": {
@@ -12060,10 +12062,6 @@
       "version": "1.1.1",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/credential-subject": {
-      "resolved": "lambdas/credential-subject",
-      "link": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",

--- a/step-functions/fetch-questions.asl.json
+++ b/step-functions/fetch-questions.asl.json
@@ -149,23 +149,43 @@
         "SecretId": "HMRCBearerToken"
       },
       "Resource": "arn:aws:states:::aws-sdk:secretsmanager:getSecretValue",
-      "Next": "Get Questions URL and User Agent",
+      "Next": "Create Parameters State Location",
       "ResultSelector": {
         "value.$": "$.SecretString"
       },
       "ResultPath": "$.bearerToken"
     },
-    "Get Questions URL and User Agent": {
-      "Type": "Task",
-      "Next": "Invoke FetchQuestions Lambda",
-      "Parameters": {
-        "Names": ["${QuestionsUrl}", "${UserAgent}"]
+    "Create Parameters State Location": {
+      "Type": "Pass",
+      "Next": "GetParameter QuestionsUrl",
+      "Result": {
+        "url": "NOT_SET",
+        "userAgent": "NOT_SET"
       },
-      "Resource": "arn:aws:states:::aws-sdk:ssm:getParameters",
-      "ResultPath": "$.parameters",
+      "ResultPath": "$.parameters"
+    },
+    "GetParameter QuestionsUrl": {
+      "Type": "Task",
+      "Parameters": {
+        "Name": "${QuestionsUrl}"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getParameter",
+      "Next": "GetParameter User Agent",
       "ResultSelector": {
-        "url.$": "$.Parameters[0].Value",
-        "userAgent.$": "$.Parameters[1].Value"
+        "value.$": "$.Parameter.Value"
+      },
+      "ResultPath": "$.parameters.url"
+    },
+    "GetParameter User Agent": {
+      "Type": "Task",
+      "Parameters": {
+        "Name": "${UserAgent}"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getParameter",
+      "Next": "Invoke FetchQuestions Lambda",
+      "ResultPath": "$.parameters.userAgent",
+      "ResultSelector": {
+        "value.$": "$.Parameter.Value"
       }
     },
     "Invoke FetchQuestions Lambda": {

--- a/step-functions/post-answer.asl.json
+++ b/step-functions/post-answer.asl.json
@@ -253,23 +253,43 @@
         "SecretId": "HMRCBearerToken"
       },
       "Resource": "arn:aws:states:::aws-sdk:secretsmanager:getSecretValue",
-      "Next": "Get Answers URL and User Agent",
+      "Next": "Create Parameters State Location",
       "ResultSelector": {
         "value.$": "$.SecretString"
       },
       "ResultPath": "$.bearerToken"
     },
-    "Get Answers URL and User Agent": {
-      "Type": "Task",
-      "Next": "Invoke Submit Answers Lambda",
-      "Parameters": {
-        "Names": ["${AnswersUrl}", "${UserAgent}"]
+    "Create Parameters State Location": {
+      "Type": "Pass",
+      "Next": "GetParameter AnswersUrl",
+      "Result": {
+        "url": "NOT_SET",
+        "userAgent": "NOT_SET"
       },
-      "Resource": "arn:aws:states:::aws-sdk:ssm:getParameters",
-      "ResultPath": "$.parameters",
+      "ResultPath": "$.parameters"
+    },
+    "GetParameter AnswersUrl": {
+      "Type": "Task",
+      "Parameters": {
+        "Name": "${AnswersUrl}"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getParameter",
+      "Next": "GetParameter User Agent",
       "ResultSelector": {
-        "url.$": "$.Parameters[0].Value",
-        "userAgent.$": "$.Parameters[1].Value"
+        "value.$": "$.Parameter.Value"
+      },
+      "ResultPath": "$.parameters.url"
+    },
+    "GetParameter User Agent": {
+      "Type": "Task",
+      "Parameters": {
+        "Name": "${UserAgent}"
+      },
+      "Resource": "arn:aws:states:::aws-sdk:ssm:getParameter",
+      "Next": "Invoke Submit Answers Lambda",
+      "ResultPath": "$.parameters.userAgent",
+      "ResultSelector": {
+        "value.$": "$.Parameter.Value"
       }
     },
     "Invoke Submit Answers Lambda": {


### PR DESCRIPTION
## Proposed changes

### What changed

Changed to fetching parameters individually to correct parameters in fetch-questions/post-answer sometimes being re-ordered.

### Why did it change

When prefix was enabled the parameter order can be reversed (url/useragent). 
Using hardcoded array indexes are not safe in this scenario.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1128](https://govukverify.atlassian.net/browse/LIME-1128)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc. -->


[LIME-1128]: https://govukverify.atlassian.net/browse/LIME-1128?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ