### PR TITLE
LIME-1085 Ensure we are tracking key metrics

### DIFF
--- a/lambdas/evidence-check-details/src/check-details-handler.ts
+++ b/lambdas/evidence-check-details/src/check-details-handler.ts
@@ -1,4 +1,4 @@
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { QuestionInfo, Response } from "./question-info-event";
 import {

--- a/lambdas/execute-state-machine/src/execute-state-machine-handler.ts
+++ b/lambdas/execute-state-machine/src/execute-state-machine-handler.ts
@@ -1,4 +1,4 @@
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 import { SFNClient, StartSyncExecutionCommand } from "@aws-sdk/client-sfn";
 import { fromEnv } from "@aws-sdk/credential-providers";
 import { Logger } from "@aws-lambda-powertools/logger";

--- a/lambdas/fetch-questions/tests/fetch-questions-handler.test.ts
+++ b/lambdas/fetch-questions/tests/fetch-questions-handler.test.ts
@@ -1,4 +1,4 @@
-import { MetricUnits } from "@aws-lambda-powertools/metrics";
+import { MetricUnit } from "@aws-lambda-powertools/metrics";
 import { FetchQuestionsHandler } from "../src/fetch-questions-handler";
 import { Question, QuestionsResult } from "../src/types/questions-result-types";
 import { QuestionsRetrievalService } from "../src/services/questions-retrieval-service";
@@ -150,7 +150,7 @@ describe("FetchQuestionsHandler", () => {
 
         expect(mockMetricsProbeSpy).toHaveBeenCalledWith(
           HandlerMetric.CompletionStatus,
-          MetricUnits.Count,
+          MetricUnit.Count,
           CompletionStatus.OK
         );
 
@@ -211,7 +211,7 @@ describe("FetchQuestionsHandler", () => {
 
         expect(mockMetricsProbeSpy).toHaveBeenCalledWith(
           HandlerMetric.CompletionStatus,
-          MetricUnits.Count,
+          MetricUnit.Count,
           CompletionStatus.OK
         );
 
@@ -251,7 +251,7 @@ describe("FetchQuestionsHandler", () => {
 
       expect(mockMetricsProbeSpy).toHaveBeenCalledWith(
         HandlerMetric.CompletionStatus,
-        MetricUnits.Count,
+        MetricUnit.Count,
         CompletionStatus.ERROR
       );
 
@@ -302,7 +302,7 @@ describe("FetchQuestionsHandler", () => {
 
       expect(mockMetricsProbeSpy).toHaveBeenCalledWith(
         HandlerMetric.CompletionStatus,
-        MetricUnits.Count,
+        MetricUnit.Count,
         CompletionStatus.ERROR
       );
 

--- a/lambdas/fetch-questions/tests/jest.custom.ts
+++ b/lambdas/fetch-questions/tests/jest.custom.ts
@@ -1,0 +1,31 @@
+declare global {
+  namespace jest {
+    interface Matchers<R> {
+      toBeWithinRange(a: number, b: number): R;
+    }
+    interface Expect {
+      toBeWithinRange(a: number, b: number): any;
+    }
+
+    interface InverseAsymmetricMatchers {
+      toBeWithinRange(a: number, b: number): any;
+    }
+  }
+}
+
+export function toBeWithinRange(value: number, lower: number, top: number) {
+  const pass: boolean = value >= lower && value <= top;
+  if (pass) {
+    return {
+      message: () => `expected ${value} not within range ${lower} to ${top}`,
+      pass: true,
+    };
+  } else {
+    return {
+      message: () => `expected ${value} not within range ${lower} to ${top}`,
+      pass: false,
+    };
+  }
+}
+
+expect.extend({ toBeWithinRange });

--- a/lambdas/fetch-questions/tests/services/filter-questions-service.test.ts
+++ b/lambdas/fetch-questions/tests/services/filter-questions-service.test.ts
@@ -1,19 +1,37 @@
 import { FilterQuestionsService } from "../../src/services/filter-questions-service";
 import { MetricsProbe } from "../../../../lib/src/Service/metrics-probe";
 import { Question } from "../../src/types/questions-result-types";
+import { Classification } from "../../../../lib/src/MetricTypes/metric-classifications";
+import { MetricUnit } from "@aws-lambda-powertools/metrics";
+
+// For Custom InRange Matcher
+import "../jest.custom";
+
+jest.mock("@aws-lambda-powertools/metrics");
+jest.mock("../../../../lib/src/Service/metrics-probe");
 
 describe("FilterQuestionsService", () => {
   process.env.QUESTIONS_TABLE_NAME = "QUESTIONS_TABLE_NAME";
   let service: FilterQuestionsService;
 
+  let mockMetricsProbe: jest.MockedObjectDeep<typeof MetricsProbe>;
+
+  let mockCaptureServiceMetricMetricsProbeSpy: jest.SpyInstance;
+
   beforeEach(() => {
     jest.clearAllMocks();
 
-    const metricsProbe: MetricsProbe = new MetricsProbe();
+    mockMetricsProbe = jest.mocked(MetricsProbe);
 
-    service = new FilterQuestionsService(metricsProbe);
+    mockCaptureServiceMetricMetricsProbeSpy = jest.spyOn(
+      mockMetricsProbe.prototype,
+      "captureServiceMetric"
+    );
+
+    service = new FilterQuestionsService(mockMetricsProbe.prototype);
   });
 
+  // NOTE: The return of this test can be 3 questions from 2 or 3 categories
   it("Happy Path >3 questions, 3 categories", async () => {
     const allQuestionsArray: Question[] = [
       new Question("rti-p60-payment-for-year", undefined, undefined),
@@ -25,6 +43,80 @@ describe("FilterQuestionsService", () => {
     const filteredQuestionsCount =
       await service.filterQuestions(allQuestionsArray);
     expect(filteredQuestionsCount.length).toEqual(3);
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreFilteringQuestionKeyCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      5
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreFilteringCategoryCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      3
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreRtiP60PayslipCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      2
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreTaxCreditsCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      2
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreSelfAssessmentCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      1
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PostFilteringQuestionKeyCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      3
+    );
+
+    // can be 2 or 3 categories depending on filtering
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PostFilteringCategoryCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      expect.toBeWithinRange(2, 3)
+    );
+
+    // Ensure our mappings are known
+    expect(mockCaptureServiceMetricMetricsProbeSpy).not.toHaveBeenCalledWith(
+      "PreUnknownCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      expect.any(Number)
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).not.toHaveBeenCalledWith(
+      "PostUnknownCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      expect.any(Number)
+    );
   });
 
   it("Happy Path 3 questions, 2 categories", async () => {
@@ -36,6 +128,71 @@ describe("FilterQuestionsService", () => {
     const filteredQuestionsCount =
       await service.filterQuestions(allQuestionsArray);
     expect(filteredQuestionsCount.length).toEqual(3);
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreFilteringQuestionKeyCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      3
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreFilteringCategoryCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      2
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreRtiP60PayslipCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      2
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreSelfAssessmentCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      1
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PostFilteringQuestionKeyCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      3
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PostFilteringCategoryCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      2
+    );
+
+    // Ensure our mappings are known
+    expect(mockCaptureServiceMetricMetricsProbeSpy).not.toHaveBeenCalledWith(
+      "PreUnknownCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      expect.any(Number)
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).not.toHaveBeenCalledWith(
+      "PostUnknownCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      expect.any(Number)
+    );
   });
 
   it("Happy Path 2 questions, 2 categories", async () => {
@@ -46,6 +203,71 @@ describe("FilterQuestionsService", () => {
     const filteredQuestionsCount =
       await service.filterQuestions(allQuestionsArray);
     expect(filteredQuestionsCount.length).toEqual(2);
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreFilteringQuestionKeyCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      2
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreFilteringCategoryCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      2
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreRtiP60PayslipCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      1
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreSelfAssessmentCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      1
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PostFilteringQuestionKeyCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      2
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PostFilteringCategoryCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      2
+    );
+
+    // Ensure our mappings are known
+    expect(mockCaptureServiceMetricMetricsProbeSpy).not.toHaveBeenCalledWith(
+      "PreUnknownCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      expect.any(Number)
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).not.toHaveBeenCalledWith(
+      "PostUnknownCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      expect.any(Number)
+    );
   });
 
   it("Unhappy Path >3 questions, 1 category", async () => {
@@ -66,6 +288,63 @@ describe("FilterQuestionsService", () => {
     const filteredQuestionsCount =
       await service.filterQuestions(allQuestionsArray);
     expect(filteredQuestionsCount.length).toEqual(0);
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreFilteringQuestionKeyCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      4
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreFilteringCategoryCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      1
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreRtiP60PayslipCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      4
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PostFilteringQuestionKeyCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      0
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PostFilteringCategoryCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      0
+    );
+
+    // Ensure our mappings are known
+    expect(mockCaptureServiceMetricMetricsProbeSpy).not.toHaveBeenCalledWith(
+      "PreUnknownCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      expect.any(Number)
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).not.toHaveBeenCalledWith(
+      "PostUnknownCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      expect.any(Number)
+    );
   });
 
   it("Unhappy Path 2 questions, 1 category", async () => {
@@ -76,6 +355,63 @@ describe("FilterQuestionsService", () => {
     const filteredQuestionsCount =
       await service.filterQuestions(allQuestionsArray);
     expect(filteredQuestionsCount.length).toEqual(0);
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreFilteringQuestionKeyCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      2
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreFilteringCategoryCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      1
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreRtiP60PayslipCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      2
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PostFilteringQuestionKeyCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      0
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PostFilteringCategoryCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      0
+    );
+
+    // Ensure our mappings are known
+    expect(mockCaptureServiceMetricMetricsProbeSpy).not.toHaveBeenCalledWith(
+      "PreUnknownCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      expect.any(Number)
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).not.toHaveBeenCalledWith(
+      "PostUnknownCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      expect.any(Number)
+    );
   });
 
   it("Unhappy Path 1 question", async () => {
@@ -85,6 +421,63 @@ describe("FilterQuestionsService", () => {
     const filteredQuestionsCount =
       await service.filterQuestions(allQuestionsArray);
     expect(filteredQuestionsCount.length).toEqual(0);
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreFilteringQuestionKeyCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      1
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreFilteringCategoryCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      1
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreRtiP60PayslipCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      1
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PostFilteringQuestionKeyCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      0
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PostFilteringCategoryCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      0
+    );
+
+    // Ensure our mappings are known
+    expect(mockCaptureServiceMetricMetricsProbeSpy).not.toHaveBeenCalledWith(
+      "PreUnknownCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      expect.any(Number)
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).not.toHaveBeenCalledWith(
+      "PostUnknownCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      expect.any(Number)
+    );
   });
 
   it("Unhappy Path no questions", async () => {
@@ -92,6 +485,55 @@ describe("FilterQuestionsService", () => {
     const filteredQuestionsCount =
       await service.filterQuestions(allQuestionsArray);
     expect(filteredQuestionsCount.length).toEqual(0);
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreFilteringQuestionKeyCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      0
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreFilteringCategoryCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      0
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PostFilteringQuestionKeyCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      0
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PostFilteringCategoryCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      0
+    );
+
+    // Ensure our mappings are known
+    expect(mockCaptureServiceMetricMetricsProbeSpy).not.toHaveBeenCalledWith(
+      "PreUnknownCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      expect.any(Number)
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).not.toHaveBeenCalledWith(
+      "PostUnknownCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      expect.any(Number)
+    );
   });
 
   it("Unhappy Path 3 questions, 2 categories (low confidence)", async () => {
@@ -103,5 +545,70 @@ describe("FilterQuestionsService", () => {
     const filteredQuestionsCount =
       await service.filterQuestions(allQuestionsArray);
     expect(filteredQuestionsCount.length).toEqual(0);
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreFilteringQuestionKeyCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      3
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreFilteringCategoryCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      2
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreRtiP60PayslipCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      2
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PreTaxCreditsCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      1
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PostFilteringQuestionKeyCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      0
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
+      "PostFilteringCategoryCount",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      0
+    );
+
+    // Ensure our mappings are known
+    expect(mockCaptureServiceMetricMetricsProbeSpy).not.toHaveBeenCalledWith(
+      "PreUnknownCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      expect.any(Number)
+    );
+
+    expect(mockCaptureServiceMetricMetricsProbeSpy).not.toHaveBeenCalledWith(
+      "PostUnknownCategory",
+      Classification.SERVICE_SPECIFIC,
+      "FilterQuestionService",
+      MetricUnit.Count,
+      expect.any(Number)
+    );
   });
 });

--- a/lambdas/fetch-questions/tests/services/questions-retrieval-service.test.ts
+++ b/lambdas/fetch-questions/tests/services/questions-retrieval-service.test.ts
@@ -1,4 +1,4 @@
-import { MetricUnits } from "@aws-lambda-powertools/metrics";
+import { MetricUnit } from "@aws-lambda-powertools/metrics";
 import { QuestionsResult } from "../../src/types/questions-result-types";
 
 import {
@@ -12,7 +12,6 @@ import { Classification } from "../../../../lib/src/MetricTypes/metric-classific
 
 enum QuestionServiceMetrics {
   ResponseQuestionKeyCount = "ResponseQuestionKeyCount",
-  MappedQuestionKeyCount = "MappedQuestionKeyCount",
 }
 
 jest.mock("@aws-lambda-powertools/metrics");
@@ -101,7 +100,7 @@ describe("QuestionsRetrievalService", () => {
         HTTPMetric.ResponseLatency,
         Classification.HTTP,
         "QuestionsRetrievalService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         expect.any(Number)
       );
 
@@ -110,7 +109,7 @@ describe("QuestionsRetrievalService", () => {
         HTTPMetric.HTTPStatusCode,
         Classification.HTTP,
         "QuestionsRetrievalService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         200
       );
 
@@ -119,25 +118,15 @@ describe("QuestionsRetrievalService", () => {
         HTTPMetric.ResponseValidity,
         Classification.HTTP,
         "QuestionsRetrievalService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         ResponseValidity.Valid
       );
 
-      // Processed Questions to match response
       expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
         QuestionServiceMetrics.ResponseQuestionKeyCount,
         Classification.SERVICE_SPECIFIC,
         "QuestionsRetrievalService",
-        MetricUnits.Count,
-        apiResponse["questions"].length
-      );
-
-      // Mapped Questions to the same as Processed (until fitering is added)
-      expect(mockCaptureServiceMetricMetricsProbeSpy).toHaveBeenCalledWith(
-        QuestionServiceMetrics.MappedQuestionKeyCount,
-        Classification.SERVICE_SPECIFIC,
-        "QuestionsRetrievalService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         apiResponse["questions"].length
       );
     });
@@ -156,9 +145,6 @@ describe("QuestionsRetrievalService", () => {
         })
       ) as jest.Mock;
 
-      // const questionsResult: QuestionsResult =
-      //   await questionsRetrievalService.retrieveQuestions(mockInputEvent);
-
       await expect(
         questionsRetrievalService.retrieveQuestions(mockInputEvent)
       ).rejects.toEqual(
@@ -172,7 +158,7 @@ describe("QuestionsRetrievalService", () => {
         HTTPMetric.ResponseLatency,
         Classification.HTTP,
         "QuestionsRetrievalService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         expect.any(Number)
       );
 
@@ -181,7 +167,7 @@ describe("QuestionsRetrievalService", () => {
         HTTPMetric.HTTPStatusCode,
         Classification.HTTP,
         "QuestionsRetrievalService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         200
       );
 
@@ -190,7 +176,7 @@ describe("QuestionsRetrievalService", () => {
         HTTPMetric.ResponseValidity,
         Classification.HTTP,
         "QuestionsRetrievalService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         ResponseValidity.Invalid
       );
     });
@@ -223,7 +209,7 @@ describe("QuestionsRetrievalService", () => {
         HTTPMetric.ResponseLatency,
         Classification.HTTP,
         "QuestionsRetrievalService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         expect.any(Number)
       );
 
@@ -232,7 +218,7 @@ describe("QuestionsRetrievalService", () => {
         HTTPMetric.HTTPStatusCode,
         Classification.HTTP,
         "QuestionsRetrievalService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         200
       );
 
@@ -241,7 +227,7 @@ describe("QuestionsRetrievalService", () => {
         HTTPMetric.ResponseValidity,
         Classification.HTTP,
         "QuestionsRetrievalService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         ResponseValidity.Invalid
       );
     });
@@ -274,7 +260,7 @@ describe("QuestionsRetrievalService", () => {
         HTTPMetric.ResponseLatency,
         Classification.HTTP,
         "QuestionsRetrievalService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         expect.any(Number)
       );
 
@@ -283,7 +269,7 @@ describe("QuestionsRetrievalService", () => {
         HTTPMetric.HTTPStatusCode,
         Classification.HTTP,
         "QuestionsRetrievalService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         401
       );
     });
@@ -318,7 +304,7 @@ describe("QuestionsRetrievalService", () => {
           HTTPMetric.ResponseLatency,
           Classification.HTTP,
           "QuestionsRetrievalService",
-          MetricUnits.Count,
+          MetricUnit.Count,
           expect.any(Number)
         );
 
@@ -327,7 +313,7 @@ describe("QuestionsRetrievalService", () => {
           HTTPMetric.HTTPStatusCode,
           Classification.HTTP,
           "QuestionsRetrievalService",
-          MetricUnits.Count,
+          MetricUnit.Count,
           httpStatus
         );
       }

--- a/lambdas/fetch-questions/tsconfig.json
+++ b/lambdas/fetch-questions/tsconfig.json
@@ -15,5 +15,10 @@
     "noImplicitAny": true
   },
   "exclude": ["node_modules", "build", "coverage"],
-  "include": ["src", "tests", "../../lib/src/Service/metrics-probe.ts"]
+  "include": [
+    "src",
+    "tests",
+    "../../lib/src/Service/metrics-probe.ts",
+    "tests/jest.custom.ts"
+  ]
 }

--- a/lambdas/issue-credential/src/time-handler.ts
+++ b/lambdas/issue-credential/src/time-handler.ts
@@ -1,4 +1,4 @@
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 import { Logger } from "@aws-lambda-powertools/logger";
 import { TimeEvent } from "./time-event";
 

--- a/lambdas/jwt-signer/src/jwt-signer-handler.ts
+++ b/lambdas/jwt-signer/src/jwt-signer-handler.ts
@@ -1,4 +1,4 @@
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 import { createHash } from "crypto";
 import sigFormatter from "ecdsa-sig-formatter";
 import { fromEnv } from "@aws-sdk/credential-providers";

--- a/lambdas/submit-answer/src/create-auth-code-handler.ts
+++ b/lambdas/submit-answer/src/create-auth-code-handler.ts
@@ -1,4 +1,4 @@
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 import { Logger } from "@aws-lambda-powertools/logger";
 
 const logger = new Logger();

--- a/lambdas/submit-answer/tests/services/submit-answer-service.disabled.ts
+++ b/lambdas/submit-answer/tests/services/submit-answer-service.disabled.ts
@@ -1,5 +1,5 @@
 /*
-import { MetricUnits } from "@aws-lambda-powertools/metrics";
+import { MetricUnit } from "@aws-lambda-powertools/metrics";
 
 import { DynamoDBDocument, GetCommand } from "@aws-sdk/lib-dynamodb";
 
@@ -136,7 +136,7 @@ describe("SubmitAnswerService", () => {
         HTTPMetric.ResponseLatency,
         Classification.HTTP,
         "SubmitAnswersService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         expect.any(Number)
       );
 
@@ -145,7 +145,7 @@ describe("SubmitAnswerService", () => {
         HTTPMetric.HTTPStatusCode,
         Classification.HTTP,
         "SubmitAnswersService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         200
       );
 
@@ -154,7 +154,7 @@ describe("SubmitAnswerService", () => {
         HTTPMetric.ResponseValidity,
         Classification.HTTP,
         "SubmitAnswersService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         ResponseValidity.Valid
       );
 
@@ -163,7 +163,7 @@ describe("SubmitAnswerService", () => {
         AnswerServiceMetrics.ResponseQuestionKeyCount,
         Classification.SERVICE_SPECIFIC,
         "SubmitAnswersService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         apiResponse["answers"].length
       );
 
@@ -172,7 +172,7 @@ describe("SubmitAnswerService", () => {
         AnswerServiceMetrics.MappedAnswerKeyCount,
         Classification.SERVICE_SPECIFIC,
         "SubmitAnswersService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         apiResponse["answers"].length
       );
     });
@@ -204,7 +204,7 @@ describe("SubmitAnswerService", () => {
         HTTPMetric.ResponseLatency,
         Classification.HTTP,
         "SubmitAnswersService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         expect.any(Number)
       );
 
@@ -213,7 +213,7 @@ describe("SubmitAnswerService", () => {
         HTTPMetric.HTTPStatusCode,
         Classification.HTTP,
         "SubmitAnswersService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         200
       );
 
@@ -222,7 +222,7 @@ describe("SubmitAnswerService", () => {
         HTTPMetric.ResponseValidity,
         Classification.HTTP,
         "SubmitAnswersService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         ResponseValidity.Invalid
       );
     });
@@ -255,7 +255,7 @@ describe("SubmitAnswerService", () => {
         HTTPMetric.ResponseLatency,
         Classification.HTTP,
         "SubmitAnswersService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         expect.any(Number)
       );
 
@@ -264,7 +264,7 @@ describe("SubmitAnswerService", () => {
         HTTPMetric.HTTPStatusCode,
         Classification.HTTP,
         "SubmitAnswersService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         200
       );
 
@@ -273,7 +273,7 @@ describe("SubmitAnswerService", () => {
         HTTPMetric.ResponseValidity,
         Classification.HTTP,
         "SubmitAnswersService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         ResponseValidity.Invalid
       );
     });
@@ -306,7 +306,7 @@ describe("SubmitAnswerService", () => {
         HTTPMetric.ResponseLatency,
         Classification.HTTP,
         "SubmitAnswersService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         expect.any(Number)
       );
 
@@ -315,7 +315,7 @@ describe("SubmitAnswerService", () => {
         HTTPMetric.HTTPStatusCode,
         Classification.HTTP,
         "SubmitAnswersService",
-        MetricUnits.Count,
+        MetricUnit.Count,
         401
       );
     });
@@ -350,7 +350,7 @@ describe("SubmitAnswerService", () => {
           HTTPMetric.ResponseLatency,
           Classification.HTTP,
           "SubmitAnswersService",
-          MetricUnits.Count,
+          MetricUnit.Count,
           expect.any(Number)
         );
 
@@ -359,7 +359,7 @@ describe("SubmitAnswerService", () => {
           HTTPMetric.HTTPStatusCode,
           Classification.HTTP,
           "SubmitAnswersService",
-          MetricUnits.Count,
+          MetricUnit.Count,
           httpStatus
         );
       }

--- a/lambdas/time/src/current-time-handler.ts
+++ b/lambdas/time/src/current-time-handler.ts
@@ -1,4 +1,4 @@
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 
 export class CurrentTimeHandler implements LambdaInterface {
   public async handler(_event: unknown, _context: unknown): Promise<string> {

--- a/lib/src/Service/metrics-probe.ts
+++ b/lib/src/Service/metrics-probe.ts
@@ -1,4 +1,6 @@
-import { Metrics, MetricUnits } from "@aws-lambda-powertools/metrics";
+import { Metrics } from "@aws-lambda-powertools/metrics";
+import { type MetricUnit } from "@aws-lambda-powertools/metrics";
+
 import { Classification } from "../MetricTypes/metric-classifications";
 
 // exported for attaching to cold start anotation
@@ -16,7 +18,7 @@ export class MetricsProbe {
 
   public captureMetric(
     metricName: string,
-    unit: MetricUnits,
+    unit: (typeof MetricUnit)[keyof typeof MetricUnit],
     metricValue: number
   ) {
     this.baseMetrics.addMetric(metricName, unit, metricValue);
@@ -26,7 +28,7 @@ export class MetricsProbe {
     metricName: string,
     classification: Classification,
     dimensionValue: string,
-    unit: MetricUnits,
+    unit: (typeof MetricUnit)[keyof typeof MetricUnit],
     metricValue: number
   ) {
     const singleMetric: Metrics = this.baseMetrics.singleMetric();

--- a/lib/src/Service/stop-watch.ts
+++ b/lib/src/Service/stop-watch.ts
@@ -1,0 +1,11 @@
+export class StopWatch {
+  startTime: number = 0;
+
+  public start() {
+    this.startTime = Date.now();
+  }
+
+  public stop(): number {
+    return Date.now() - this.startTime;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,10 @@
         "lambdas/*"
       ],
       "dependencies": {
-        "@aws-lambda-powertools/commons": "1.14.2",
-        "@aws-lambda-powertools/logger": "1.14.2",
-        "@aws-lambda-powertools/metrics": "1.14.2",
-        "@aws-lambda-powertools/tracer": "1.14.2",
+        "@aws-lambda-powertools/commons": "2.5.0",
+        "@aws-lambda-powertools/logger": "2.5.0",
+        "@aws-lambda-powertools/metrics": "2.5.0",
+        "@aws-lambda-powertools/tracer": "2.5.0",
         "@aws-sdk/client-dynamodb": "3.602.0",
         "@aws-sdk/client-kms": "3.451.0",
         "@aws-sdk/credential-providers": "3.352.0",
@@ -2289,18 +2289,20 @@
       "license": "0BSD"
     },
     "node_modules/@aws-lambda-powertools/commons": {
-      "version": "1.14.2",
-      "license": "MIT-0"
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-2.5.0.tgz",
+      "integrity": "sha512-6LTrCWknv/ey7akvEojN5qoAC2Hbb8twseYX7Efdigxs9+AadcM+P74Qh7BsMSvEiHdsIefHqtb4b13WOhFsJw=="
     },
     "node_modules/@aws-lambda-powertools/logger": {
-      "version": "1.14.2",
-      "license": "MIT-0",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-2.5.0.tgz",
+      "integrity": "sha512-lNnjvI7H3g6tpnwia8laPclzq5vzsUNlVp89FPbgs/KdSqnp5XaeNhsMGwFVy5QDHttEGI2OrsgAOFbNcf936Q==",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^1.14.2",
+        "@aws-lambda-powertools/commons": "^2.5.0",
         "lodash.merge": "^4.6.2"
       },
       "peerDependencies": {
-        "@middy/core": ">=3.x"
+        "@middy/core": "4.x || 5.x"
       },
       "peerDependenciesMeta": {
         "@middy/core": {
@@ -2309,13 +2311,14 @@
       }
     },
     "node_modules/@aws-lambda-powertools/metrics": {
-      "version": "1.14.2",
-      "license": "MIT-0",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/metrics/-/metrics-2.5.0.tgz",
+      "integrity": "sha512-CqjjcSjG6mL14RrqcsIPagoHUEWbUa+OGbaeBgbPv9/3KSxU9GViq7uDGgHfLX9HEN9k72w+Wa/ERm0eC+vxLA==",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^1.14.2"
+        "@aws-lambda-powertools/commons": "^2.5.0"
       },
       "peerDependencies": {
-        "@middy/core": ">=3.x"
+        "@middy/core": "4.x || 5.x"
       },
       "peerDependenciesMeta": {
         "@middy/core": {
@@ -2324,14 +2327,15 @@
       }
     },
     "node_modules/@aws-lambda-powertools/tracer": {
-      "version": "1.14.2",
-      "license": "MIT-0",
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/tracer/-/tracer-2.5.0.tgz",
+      "integrity": "sha512-LuX1AHXlZl48JjiBp6BXFs7LkXBwYfKoxOXRpOUd38QLz0X40R+mmjpb3IYe+tUJoq6cnI/yZrhf5MzLX5tMwg==",
       "dependencies": {
-        "@aws-lambda-powertools/commons": "^1.14.2",
-        "aws-xray-sdk-core": "^3.5.3"
+        "@aws-lambda-powertools/commons": "^2.5.0",
+        "aws-xray-sdk-core": "^3.9.0"
       },
       "peerDependencies": {
-        "@middy/core": ">=3.x"
+        "@middy/core": "4.x || 5.x"
       },
       "peerDependenciesMeta": {
         "@middy/core": {
@@ -8138,6 +8142,19 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@datastream/core": {
+      "version": "0.0.36",
+      "resolved": "https://registry.npmjs.org/@datastream/core/-/core-0.0.36.tgz",
+      "integrity": "sha512-qec5ckpnhrLL04sFkN4lOZVyYCLSUYjxmODEaEmO7qNzDwXF9laX6brgD2bd2+vXostv63yQ29yhsBNZQU6QsQ==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "cloneable-readable": "3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/android-arm": {
       "version": "0.19.5",
       "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.19.5.tgz",
@@ -8957,6 +8974,23 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@middy/core": {
+      "version": "5.4.5",
+      "resolved": "https://registry.npmjs.org/@middy/core/-/core-5.4.5.tgz",
+      "integrity": "sha512-SnCplyrjp97YWeo1TzlnnBuqXZ4iA8jlXBVNmXSwa5w9KOh6LurSMgEKTi3ktJnt0Cm71vGa+8EumVcwSEKMtQ==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "@datastream/core": "0.0.36"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/willfarrell"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -10715,6 +10749,19 @@
       "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
       "dev": true
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
@@ -11097,9 +11144,9 @@
       }
     },
     "node_modules/aws-xray-sdk-core": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.6.0.tgz",
-      "integrity": "sha512-+UnYmVEni9NNJvE6aFY1dbvMtFquXSYAj+HYfm+90icoGKYvvLD71R7PHyFFnYct5of4NFpEXJtUJrWMv8e4mQ==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/aws-xray-sdk-core/-/aws-xray-sdk-core-3.9.0.tgz",
+      "integrity": "sha512-YKzOVse7m6PCO/Uf3y3zhkWqPo5uUIU1Iin/hvL+Lpr2gFxCbNR88pkARAW2LyjvkwlcwLvx7TEoNV3SJYa4yg==",
       "dependencies": {
         "@aws-sdk/types": "^3.4.1",
         "@smithy/service-error-classification": "^2.0.4",
@@ -11318,7 +11365,7 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -11683,6 +11730,89 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/cloneable-readable": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cloneable-readable/-/cloneable-readable-3.0.0.tgz",
+      "integrity": "sha512-Lkfd9IRx1nfiBr7UHNxJSl/x7DOeUfYmxzCkxYJC2tyc/9vKgV75msgLGurGQsak/NvJDHMWcshzEXRlxfvhqg==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "readable-stream": "^4.0.0"
+      }
+    },
+    "node_modules/cloneable-readable/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
+    "node_modules/cloneable-readable/node_modules/events": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
+      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=0.8.x"
+      }
+    },
+    "node_modules/cloneable-readable/node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true,
+      "peer": true
+    },
+    "node_modules/cloneable-readable/node_modules/readable-stream": {
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.5.2.tgz",
+      "integrity": "sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "buffer": "^6.0.3",
+        "events": "^3.3.0",
+        "process": "^0.11.10",
+        "string_decoder": "^1.3.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/cls-hooked": {
@@ -13039,6 +13169,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/events": {
@@ -15855,6 +15995,16 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "optional": true,
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6.0"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -16629,7 +16779,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }

--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "deploy": "./deploy.sh"
   },
   "dependencies": {
-    "@aws-lambda-powertools/commons": "1.14.2",
-    "@aws-lambda-powertools/logger": "1.14.2",
-    "@aws-lambda-powertools/metrics": "1.14.2",
-    "@aws-lambda-powertools/tracer": "1.14.2",
+    "@aws-lambda-powertools/commons": "2.5.0",
+    "@aws-lambda-powertools/logger": "2.5.0",
+    "@aws-lambda-powertools/metrics": "2.5.0",
+    "@aws-lambda-powertools/tracer": "2.5.0",
     "@aws-sdk/client-dynamodb": "3.602.0",
     "@aws-sdk/credential-providers": "3.352.0",
     "@aws-sdk/lib-dynamodb": "3.525.0",


### PR DESCRIPTION
## Proposed changes

### What changed

	- Updates CRI to powertools 2.5.0
	- Update MetricsProbe to use 2.5.0
	- Corrects logger name in several files
	- Add cold start tracking to SubmitAnswerHandler/IssueCredentialHandler
	- Add stopwatch class for latency calculation
	- Add indepth pre and post filter category tracking in filter questions
	- Update filter questions tests to assert metrics are called correctly
	- Add custom matcher to support dynamic outcomes in filter questions tests
	- Add latency tracking for happy/error paths in submit question
	- Adds lambda completion tracking to IssueCredentialHandler

### Why did it change

To track key metrics in the current hmrc kbv journey

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1085](https://govukverify.atlassian.net/browse/LIME-1085)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc. -->


[LIME-1085]: https://govukverify.atlassian.net/browse/LIME-1085?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ