### PR TITLE
LIME-1096 Validating answers

### DIFF
--- a/.github/jest.config.ci.ts
+++ b/.github/jest.config.ci.ts
@@ -5,4 +5,5 @@ export default {
   ...baseConfig,
   rootDir: "..",
   reporters: [["github-actions", { silent: false }], "summary"],
+  coveragePathIgnorePatterns: ["<rootDir>/lambdas/answer-validation/*/*.ts"],
 } satisfies Config;

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -27,6 +27,9 @@
       "name": "GitHubTokenDetector"
     },
     {
+      "name": "GitLabTokenDetector"
+    },
+    {
       "name": "HexHighEntropyString",
       "limit": 3.0
     },
@@ -35,6 +38,9 @@
     },
     {
       "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "IPPublicDetector"
     },
     {
       "name": "JwtTokenDetector"
@@ -50,7 +56,13 @@
       "name": "NpmDetector"
     },
     {
+      "name": "OpenAIDetector"
+    },
+    {
       "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
     },
     {
       "name": "SendGridDetector"
@@ -68,16 +80,15 @@
       "name": "StripeDetector"
     },
     {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
       "name": "TwilioKeyDetector"
     }
   ],
   "filters_used": [
     {
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
-    },
-    {
-      "path": "detect_secrets.filters.common.is_baseline_file",
-      "filename": ".secrets.baseline"
     },
     {
       "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
@@ -240,9 +251,9 @@
         "filename": "step-functions/post-answer.asl.json",
         "hashed_secret": "c7372cf229fe9be17fcc7beede8abd17ae1eb123",
         "is_verified": false,
-        "line_number": 253
+        "line_number": 282
       }
     ]
   },
-  "generated_at": "2024-07-19T09:32:27Z"
+  "generated_at": "2024-07-29T14:43:03Z"
 }

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -551,6 +551,8 @@ Resources:
             FunctionName: !Ref CreateAuthCodeFunction
         - LambdaInvokePolicy:
             FunctionName: !Ref SubmitAnswerFunction
+        - LambdaInvokePolicy:
+            FunctionName: !Ref AnswerValidationFunction
         - DynamoDBReadPolicy:
             TableName: !Ref QuestionsTable
         - DynamoDBReadPolicy:
@@ -603,6 +605,7 @@ Resources:
         UserAgent: !Ref UserAgent
         BearerTokenName: !Ref BearerTokenName
         SubmitAnswersArn: !GetAtt SubmitAnswerFunction.Arn
+        AnswerValidationArn: !GetAtt AnswerValidationFunction.Arn
 
   PostAnswerStateMachineLogGroup:
     Type: AWS::Logs::LogGroup
@@ -1007,6 +1010,31 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/JwtSignerFunction
+      RetentionInDays: 30
+
+  ####################################################################
+  #                                                                  #
+  # Answer Validation Function                                       #
+  #                                                                  #
+  ####################################################################
+
+  AnswerValidationFunction:
+    Type: AWS::Serverless::Function
+    Metadata:
+      BuildMethod: esbuild
+      BuildProperties:
+        Sourcemap: true
+    Properties:
+      Handler: lambdas/answer-validation/src/answer-validation-handler.lambdaHandler
+      LoggingConfig:
+        LogGroup: !Sub /aws/lambda/${AWS::StackName}/AnswerValidationFunction
+      CodeSigningConfigArn:
+        !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
+
+  AnswerValidationFunctionLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub /aws/lambda/${AWS::StackName}/AnswerValidationFunction
       RetentionInDays: 30
 
   ####################################################################

--- a/jest.config.base.ts
+++ b/jest.config.base.ts
@@ -5,6 +5,8 @@ export default {
   clearMocks: true,
   modulePaths: ["<rootDir>/src"],
   collectCoverageFrom: ["<rootDir>/src/**/*"],
+  coveragePathIgnorePatterns: ["<rootDir>/src/answer-validation-handler.ts"],
+  testPathIgnorePatterns: ["<rootDir>/tests/answer-validation-handler.test.ts"],
   testMatch: ["<rootDir>/tests/**/*.test.ts"],
   coverageThreshold: {
     global: {

--- a/lambdas/answer-validation/jest.config.ts
+++ b/lambdas/answer-validation/jest.config.ts
@@ -1,0 +1,7 @@
+import type { Config } from "jest";
+import baseConfig from "../../jest.config.base";
+
+export default {
+  ...baseConfig,
+  displayName: "lambdas/answer-validation",
+} satisfies Config;

--- a/lambdas/answer-validation/package.json
+++ b/lambdas/answer-validation/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "answer-validation",
+  "description": "",
+  "scripts": {
+    "lint": "eslint .",
+    "lint:fix": "eslint . --fix",
+    "unit": "jest --verbose",
+    "test": "npm run unit --",
+    "test:coverage": "npm run unit -- --coverage",
+    "deploy": "../../deploy.sh",
+    "compile": "tsc"
+  },
+  "dependencies": {}
+}

--- a/lambdas/answer-validation/src/answer-validation-handler.ts
+++ b/lambdas/answer-validation/src/answer-validation-handler.ts
@@ -1,0 +1,62 @@
+import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { Logger } from "@aws-lambda-powertools/logger";
+
+const logger = new Logger({ serviceName: "AnswerValidationHandler" });
+
+export class AnswerValidationHandler implements LambdaInterface {
+  public async handler(event: any, _context: unknown): Promise<object> {
+    let result: boolean = false;
+    if (
+      event.key === "rti-p60-earnings-above-pt" ||
+      event.key === "rti-p60-postgraduate-loan-deductions" ||
+      event.key === "rti-p60-student-loan-deductions" ||
+      event.key === "sa-income-from-pensions"
+    ) {
+      result = poundValidation(event);
+    } else if (event.key === "sa-payment-details") {
+      result = sAPaymentValidation(event);
+    } else {
+      result = penceValidation(event);
+    }
+    logger.info("The answers have been successfully validated");
+    return { validated: result };
+  }
+}
+export function poundValidation(event: any): boolean {
+  if (event.value.match(/^([0-9]{0,12})$/)) {
+    logger.info("Validation in Pounds");
+    return true;
+  } else {
+    logger.info("Validation in Pounds failed");
+    return false;
+  }
+}
+
+export function penceValidation(event: any): boolean {
+  if (event.value.match(/^[0-9]*\.[0-9]{2}$/)) {
+    logger.info("Validation including pence");
+    return true;
+  } else {
+    logger.info("Validation in Pence failed");
+    return false;
+  }
+}
+
+export function sAPaymentValidation(event: any): boolean {
+  if (event.value.length > 200) {
+    logger.info("Input is too long");
+    return false;
+  }
+
+  try {
+    JSON.parse(event.value);
+    logger.info("Parsing Json:");
+    return true;
+  } catch (error) {
+    logger.info(`Parsing Json failed ${error}`);
+    return false;
+  }
+}
+
+const handlerClass = new AnswerValidationHandler();
+export const lambdaHandler = handlerClass.handler.bind(handlerClass);

--- a/lambdas/answer-validation/tests/answer-validation-handler.test.ts
+++ b/lambdas/answer-validation/tests/answer-validation-handler.test.ts
@@ -1,0 +1,69 @@
+import { AnswerValidationHandler } from "../src/answer-validation-handler";
+
+describe("AnswerValidationHandler", () => {
+  const handler = new AnswerValidationHandler();
+
+  it("should return true for correct pound validation", async () => {
+    const event = {
+      key: "rti-p60-earnings-above-pt",
+      value: "123",
+    };
+    const result = await handler.handler(event, null);
+    expect(result).toEqual({ validated: true });
+  });
+
+  it("should return false for incorrect pound validation", async () => {
+    const event = {
+      key: "sa-income-from-pensions",
+      value: "123.87",
+    };
+    const result = await handler.handler(event, null);
+    expect(result).toEqual({ validated: false });
+  });
+
+  it("should return true for incorrect penny validation", async () => {
+    const event = {
+      key: "rti-payslip-national-insurance",
+      value: "123.87",
+    };
+    const result = await handler.handler(event, null);
+    expect(result).toEqual({ validated: true });
+  });
+
+  it("should return false for incorrect penny validation", async () => {
+    const event = {
+      key: "rti-payslip-income-tax",
+      value: "1238.7",
+    };
+    const result = await handler.handler(event, null);
+    expect(result).toEqual({ validated: false });
+  });
+
+  it("should return false for incorrect penny validation in pounds", async () => {
+    const event = {
+      key: "rti-payslip-income-tax",
+      value: "12387",
+    };
+    const result = await handler.handler(event, null);
+    expect(result).toEqual({ validated: false });
+  });
+
+  it("should return true for correct Self Assessment validation", async () => {
+    const event = {
+      key: "sa-payment-details",
+      value:
+        '{"questionKey": "sa-payment-details","answer": "{\\"amount\\": 300.00,\\"paymentDate\\": \\"2010-01-01\\"}"}',
+    };
+    const result = await handler.handler(event, null);
+    expect(result).toEqual({ validated: true });
+  });
+
+  it("should return false for incorrect Self Assessment validation in pounds", async () => {
+    const event = {
+      key: "sa-payment-details",
+      value: "This is not a Json",
+    };
+    const result = await handler.handler(event, null);
+    expect(result).toEqual({ validated: false });
+  });
+});

--- a/lambdas/answer-validation/tsconfig.json
+++ b/lambdas/answer-validation/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "experimentalDecorators": true,
+    "target": "es2022",
+    "strict": true,
+    "preserveConstEnums": true,
+    "sourceMap": true,
+    "module": "es2022",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "types": ["jest", "node", "aws-lambda"],
+    "outDir": "./build/",
+    "noImplicitAny": true
+  },
+  "exclude": ["node_modules", "build", "coverage"],
+  "include": ["src", "tests"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -602,6 +602,7 @@
         "uuid": "dist/bin/uuid"
       }
     },
+    "lambdas/answer-validation": {},
     "lambdas/credential-subject": {
       "extraneous": true
     },
@@ -10814,6 +10815,10 @@
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
+    },
+    "node_modules/answer-validation": {
+      "resolved": "lambdas/answer-validation",
+      "link": true
     },
     "node_modules/anymatch": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
-    "unit": "jest --silent",
+    "unit": "jest",
     "test": "npm run unit --",
     "test:coverage": "npm run unit -- --coverage",
     "sam:validate": "cd infrastructure && sam validate && sam validate --lint",

--- a/step-functions/post-answer.asl.json
+++ b/step-functions/post-answer.asl.json
@@ -1,15 +1,44 @@
 {
   "Comment": "State machine for saving answers submitted in the HMRC KBV journey",
-  "StartAt": "Parse input",
+  "StartAt": "Invoke Validating Answers Lambda",
   "States": {
+    "Invoke Validating Answers Lambda": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "Payload.$": "$",
+        "FunctionName": "${AnswerValidationArn}"
+      },
+      "Next": "Parse input",
+      "ResultSelector": {
+        "validated.$": "$.Payload.validated"
+      },
+      "ResultPath": "$.result"
+    },
     "Parse input": {
       "Type": "Pass",
-      "Next": "Query database for the users questions",
+      "Next": "Validation Outcome",
       "Parameters": {
         "sessionId.$": "$.sessionId",
         "inputAnswer.$": "$.value",
-        "answeredQuestionKey.$": "$.key"
+        "answeredQuestionKey.$": "$.key",
+        "validated.$": "$.result.validated"
       }
+    },
+    "Validation Outcome": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.validated",
+          "BooleanEquals": true,
+          "Next": "Query database for the users questions"
+        }
+      ],
+      "Default": "Err: Invalid Answers State"
+    },
+    "Err: Invalid Answers State": {
+      "Type": "Fail",
+      "Error": "Answers in wrong format"
     },
     "Query database for the users questions": {
       "Type": "Task",


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

New lambda to handle validation of the answers after they've been received from the front end. This is part of the post-answers state machine and step function.

### Why did it change

To add another level of validation to ensure the values are correct before being sent to HMRC IVQ api.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1096](https://govukverify.atlassian.net/browse/LIME-1096)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc. -->


[LIME-1096]: https://govukverify.atlassian.net/browse/LIME-1096?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ