### PR TITLE
LIME-1111 Confirm database set up (Correct Item Expiries)

### DIFF
--- a/.github/jest.config.ci.ts
+++ b/.github/jest.config.ci.ts
@@ -5,5 +5,4 @@ export default {
   ...baseConfig,
   rootDir: "..",
   reporters: [["github-actions", { silent: false }], "summary"],
-  coveragePathIgnorePatterns: ["<rootDir>/lambdas/answer-validation/*/*.ts"],
 } satisfies Config;

--- a/feature-tests/tests/resources/step-definitions/post-answer-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/post-answer-happy-path.step.ts
@@ -128,7 +128,7 @@ defineFeature(feature, (test) => {
           EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
         )
           .post(EndPoints.ANSWER_ENDPOINT)
-          .send(ANSWER_POST_PAYLOAD_1)
+          .send(ANSWER_POST_PAYLOAD)
           .set("Content-Type", "application/json")
           .set("Accept", "application/json")
           .set("session-id", getValidSessionId);

--- a/feature-tests/utils/create-session.ts
+++ b/feature-tests/utils/create-session.ts
@@ -76,7 +76,7 @@ export async function postRequestToSessionEndpoint() {
     postSessionEndpoint.statusCode
   );
   console.log(
-    "Request to SessionId endpoint Response Body = " +
+    `Request to SessionId endpoint ${EndPoints.PRIVATE_API_GATEWAY_URL}${EndPoints.SESSION_URL} Response Body = ` +
       JSON.stringify(postSessionEndpoint.body, undefined, 2)
   );
   console.log("SESSION_ID = ", postSessionEndpoint.body.session_id);

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1110,15 +1110,16 @@ Resources:
         Sourcemap: true
     Properties:
       Handler: lambdas/answer-validation/src/answer-validation-handler.lambdaHandler
+      FunctionName: !Sub "${AWS::StackName}-answer-validation"
       LoggingConfig:
-        LogGroup: !Sub /aws/lambda/${AWS::StackName}/AnswerValidationFunction
+        LogGroup: !Sub "/aws/lambda/${AWS::StackName}-AnswerValidationFunction"
       CodeSigningConfigArn:
         !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
 
   AnswerValidationFunctionLogGroup:
     Type: AWS::Logs::LogGroup
     Properties:
-      LogGroupName: !Sub /aws/lambda/${AWS::StackName}/AnswerValidationFunction
+      LogGroupName: !Sub "/aws/lambda/${AnswerValidationFunction}"
       RetentionInDays: 30
 
   ####################################################################

--- a/jest.config.base.ts
+++ b/jest.config.base.ts
@@ -5,11 +5,7 @@ export default {
   clearMocks: true,
   modulePaths: ["<rootDir>/src"],
   collectCoverageFrom: ["<rootDir>/src/**/*"],
-  coveragePathIgnorePatterns: [
-    "<rootDir>/src/answer-validation-handler.ts",
-    "<rootDir>/tests/jest.custom.ts",
-  ],
-  testPathIgnorePatterns: ["<rootDir>/tests/answer-validation-handler.test.ts"],
+  coveragePathIgnorePatterns: ["<rootDir>/tests/jest.custom.ts"],
   testMatch: ["<rootDir>/tests/**/*.test.ts"],
   coverageThreshold: {
     global: {

--- a/lambdas/answer-validation/src/answer-validation-handler.ts
+++ b/lambdas/answer-validation/src/answer-validation-handler.ts
@@ -1,4 +1,4 @@
-import { LambdaInterface } from "@aws-lambda-powertools/commons";
+import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 import { Logger } from "@aws-lambda-powertools/logger";
 
 const logger = new Logger({ serviceName: "AnswerValidationHandler" });

--- a/lambdas/submit-answer/src/services/results-service.ts
+++ b/lambdas/submit-answer/src/services/results-service.ts
@@ -26,7 +26,7 @@ export class ResultsService {
   public async saveResults(
     sessionId: string,
     correlationId: string,
-    ttl: number,
+    expiryDate: number,
     answerResults: SubmitAnswerResult[],
     verificationScore: number,
     checkDetailsCount: number,
@@ -49,7 +49,7 @@ export class ResultsService {
     const answerResultItem: AnswerResultItem = new AnswerResultItem(
       sessionId,
       correlationId,
-      ttl,
+      expiryDate,
       answerResults,
       verificationScore,
       checkDetailsCount > MINIMUM_QUESTION_COUNT

--- a/lambdas/submit-answer/src/types/answer-result-types.ts
+++ b/lambdas/submit-answer/src/types/answer-result-types.ts
@@ -21,7 +21,7 @@ export class Answer {
 export class AnswerResultItem {
   sessionId: string;
   correlationId: string;
-  ttl: number;
+  expiryDate: number;
   answers: SubmitAnswerResult[];
   verificationScore: number;
   ci?: Array<string>;
@@ -31,7 +31,7 @@ export class AnswerResultItem {
   constructor(
     sessionId: string,
     correlationId: string,
-    ttl: number,
+    expiryDate: number,
     answers: SubmitAnswerResult[],
     verificationScore: number,
     checkDetailsCount?: number,
@@ -40,7 +40,7 @@ export class AnswerResultItem {
   ) {
     this.sessionId = sessionId;
     this.correlationId = correlationId;
-    this.ttl = ttl;
+    this.expiryDate = expiryDate;
     this.answers = answers;
     this.verificationScore = verificationScore;
     this.checkDetailsCount = checkDetailsCount;

--- a/step-functions/post-answer.asl.json
+++ b/step-functions/post-answer.asl.json
@@ -1,7 +1,64 @@
 {
   "Comment": "State machine for saving answers submitted in the HMRC KBV journey",
-  "StartAt": "Invoke Validating Answers Lambda",
+  "StartAt": "Check Session-Id is Present",
   "States": {
+    "Check Session-Id is Present": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.sessionId",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.sessionId",
+              "IsString": true
+            }
+          ],
+          "Next": "DynamoDB Get SessionItem"
+        }
+      ],
+      "Default": "Err: Fail SessionId missing"
+    },
+    "DynamoDB Get SessionItem": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:getItem",
+      "Parameters": {
+        "TableName": "${SessionTableName}",
+        "Key": {
+          "sessionId": {
+            "S.$": "$.sessionId"
+          }
+        }
+      },
+      "Next": "Is there a sessionItem for the sessionId",
+      "TimeoutSeconds": 5,
+      "ResultPath": "$.sessionItem"
+    },
+    "Is there a sessionItem for the sessionId": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "And": [
+            {
+              "Variable": "$.sessionItem.Item.sessionId.S",
+              "IsPresent": true
+            },
+            {
+              "Variable": "$.sessionItem.Item.sessionId.S",
+              "IsString": true
+            },
+            {
+              "Variable": "$.sessionItem.Item.sessionId.S",
+              "StringEqualsPath": "$.sessionId"
+            }
+          ],
+          "Next": "Invoke Validating Answers Lambda"
+        }
+      ],
+      "Default": "Err: SessionItem not found"
+    },
     "Invoke Validating Answers Lambda": {
       "Type": "Task",
       "Resource": "arn:aws:states:::lambda:invoke",
@@ -20,6 +77,7 @@
       "Next": "Validation Outcome",
       "Parameters": {
         "sessionId.$": "$.sessionId",
+        "sessionItem.$": "$.sessionItem",
         "inputAnswer.$": "$.value",
         "answeredQuestionKey.$": "$.key",
         "validated.$": "$.result.validated"
@@ -147,8 +205,8 @@
           "correlationId": {
             "S.$": "$.usersQuestions.Items[0].correlationId.S"
           },
-          "ttl": {
-            "S": "$.time"
+          "expiryDate": {
+            "N.$": "$.sessionItem.Item.expiryDate.N"
           },
           "answers": {
             "L.$": "$.answers[?(@.M)]"
@@ -422,6 +480,14 @@
     "Err: Lambda responded unexpectedly": {
       "Type": "Fail",
       "Error": "Lambda responded unexpectedly"
+    },
+    "Err: Fail SessionId missing": {
+      "Type": "Fail",
+      "Error": "SessionId missing or not found"
+    },
+    "Err: SessionItem not found": {
+      "Type": "Fail",
+      "Error": "SessionItem not found"
     },
     "Success": {
       "Type": "Succeed"


### PR DESCRIPTION
## Proposed changes

### What changed

	- Add Session Check to PostAnswers statemachien
	- Use SessioItem's TTL value in AnswersTable DB save
	- Correct AnswersTable DB save TTL (S->N)
	- Add basic validation to SubmitAnswerHandler
	- use incomming sessionItem's TTL in answers save
	- Correct fieldname used for TTL to expiryDate (ttl in several places)

### Why did it change

To ensure dynamodb items expire as expected.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1111](https://govukverify.atlassian.net/browse/LIME-1111)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc. -->


[LIME-1111]: https://govukverify.atlassian.net/browse/LIME-1111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ