### PR TITLE
LIME-1227: Added separate method for decrypting the VC

### DIFF
--- a/feature-tests/README.md
+++ b/feature-tests/README.md
@@ -20,15 +20,12 @@ Set up the following env vars.
 ```shell
 cd feature-tests
 npm install && npm build
-export TEST_ENVIRONMENT=dev
-export SAM_STACK_NAME=stackName
-export tagFilter=@regression
 ```
 
 To run all API tests locally in Jest via Jest.
 
 ```shell
-npm test
+tagFilter=@pre-merge npm test
 ```
 
 To run all API tests locally as the Test Container would do.

--- a/feature-tests/apiEndpoints/endpoints.ts
+++ b/feature-tests/apiEndpoints/endpoints.ts
@@ -6,6 +6,9 @@ export default class EndPoints {
   static readonly FETCH_QUESTIONS_ENDPOINT = "/fetchquestions";
   static readonly QUESTION_ENDPOINT = "/question";
   static readonly ANSWER_ENDPOINT = "/answer";
+  static readonly INVALID_FETCH_QUESTIONS_ENDPOINT = "/fetchquestion";
+  static readonly INVALID_QUESTION_ENDPOINT = "/questions";
+  static readonly INVALID_ANSWER_ENDPOINT = "/answers";
   static readonly SESSION_URL = "/session";
   static readonly CRI_ID = "hmrc-kbv-cri-dev";
   static readonly CRI_VALUE = "&cri=";

--- a/feature-tests/jest.config.ts
+++ b/feature-tests/jest.config.ts
@@ -23,6 +23,6 @@ const config: Config = {
     "default",
     ["jest-junit", { outputDirectory: "results", outputName: "report.xml" }],
   ],
-  testTimeout: 100_000,
+  testTimeout: 50_000,
 };
 export default config;

--- a/feature-tests/package-lock.json
+++ b/feature-tests/package-lock.json
@@ -10,6 +10,7 @@
       "license": "UNLICENSED",
       "dependencies": {
         "@aws-lambda-powertools/commons": "2.1.1",
+        "@aws-lambda-powertools/logger": "2.1.1",
         "@aws-lambda-powertools/parameters": "2.1.1",
         "@aws-sdk/client-cloudwatch-logs": "3.577.0",
         "@aws-sdk/client-dynamodb": "3.577.0",
@@ -158,6 +159,23 @@
       "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/commons/-/commons-2.1.1.tgz",
       "integrity": "sha512-QlvZLVJM4yXlO6mpYlYwWGaLCZTJg8WfsIH8/eT061n4BdBljW/VHMj59sHp/IljQn8HE/VdHKYHqM6vPJjYJw==",
       "license": "MIT-0"
+    },
+    "node_modules/@aws-lambda-powertools/logger": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@aws-lambda-powertools/logger/-/logger-2.1.1.tgz",
+      "integrity": "sha512-OB/ycDef8VD4OpGZcte2dxkdNWQCSxjRu8OJ2nuizh7auqZMI5LX8PYoIBEBRQC138CeJBtKKCwjSi+NOFMY1w==",
+      "dependencies": {
+        "@aws-lambda-powertools/commons": "^2.1.1",
+        "lodash.merge": "^4.6.2"
+      },
+      "peerDependencies": {
+        "@middy/core": ">=3.x"
+      },
+      "peerDependenciesMeta": {
+        "@middy/core": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@aws-lambda-powertools/parameters": {
       "version": "2.1.1",
@@ -5870,7 +5888,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/lru-cache": {

--- a/feature-tests/package.json
+++ b/feature-tests/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@aws-lambda-powertools/commons": "2.1.1",
     "@aws-lambda-powertools/parameters": "2.1.1",
+    "@aws-lambda-powertools/logger": "2.1.1",
     "@aws-sdk/client-cloudwatch-logs": "3.577.0",
     "@aws-sdk/client-dynamodb": "3.577.0",
     "@aws-sdk/client-secrets-manager": "3.577.0",

--- a/feature-tests/tests/resources/features/createSession/createSessionRequest-sessionId-HappyPath.feature
+++ b/feature-tests/tests/resources/features/createSession/createSessionRequest-sessionId-HappyPath.feature
@@ -1,7 +1,7 @@
 Feature: CORE-STUB-CreateSessionRequest-HappyPath.feature
 
-    @pre-merge
-    Scenario Outline: Happy Path - Request for user claimSet from CoreStub for Valid User
+    @pre-merge @hmrc-corestub
+    Scenario Outline: Happy Path - Request for user claimSet from CoreStub for Valid User with Nino <selectedNino>
         Given I send a new core stub request to the core stub with nino value <selectedNino>
         Examples:
             | selectedNino |

--- a/feature-tests/tests/resources/features/hmrcGet/hmrcQuestion-HappyPath.feature
+++ b/feature-tests/tests/resources/features/hmrcGet/hmrcQuestion-HappyPath.feature
@@ -1,7 +1,7 @@
 Feature: HMRC-KBV-GET-Question-HappyPath.feature
 
-    @pre-merge
-    Scenario Outline: Happy Path - Get request to /question Endpoint for userId
+    @pre-merge @hmrc-question
+    Scenario Outline: Happy Path - Get request to /question Endpoint for userId with Nino <selectedNino>
         Given I send a new questions request to the core stub with nino value <selectedNino>
         When I send a questions POST request with <contentType> and <accept> to the fetchQuestions endpoint
         When I send a GET request to the question endpoint

--- a/feature-tests/tests/resources/features/hmrcGet/hmrcQuestion-UnhappyPath.feature
+++ b/feature-tests/tests/resources/features/hmrcGet/hmrcQuestion-UnhappyPath.feature
@@ -1,0 +1,30 @@
+Feature: HMRC-KBV-GET-Question-UnhappyPath.feature
+
+    @pre-merge @hmrc-question
+    Scenario Outline: Unhappy Path - Get request to /question Endpoint - Invalid header Values - sessionId
+        Given I send a new questions request to the core stub with a nino value <selectedNino>
+        When I send a new questions POST request with <contentType> and <accept> to the fetchQuestions endpoint
+        When I send a GET request to the question endpoint with a invalid sessionId <session_id>
+        Then I should receive the appropriate response with statusCode <statusCode>
+        Examples:
+            | contentType      | accept           | statusCode | selectedNino | session_id                           |
+            | application/json | application/json | 500        | KE000000C    | 44443939-4cf4-41e9-9fee-231e16e9f382 |
+
+    @pre-merge @hmrc-Question
+    Scenario Outline: Unhappy Path - Get request to /question Endpoint - Invalid Header Values - contentType and accept
+        Given I send a valid questions request to the core stub with nino value <selectedNino>
+        And I send a POST request to the fetchQuestions endpoint
+        When I send a GET request to the question endpoint with a invalid <contentType> and <accept>
+        Then I should receive the appropriate response for the invalid headers with statusCode <statusCode>
+        Examples:
+            | contentType | accept           | statusCode | selectedNino |
+            | text/html   | application/json | 415        | KE000000C    |
+
+    @pre-merge @hmrc-question
+    Scenario Outline: Unhappy Path - Get request to /question Endpoint - Invalid Endpoint
+        Given I send a valid questions request to the core stub with selected nino value <selectedNino>
+        When I send a GET request to a Invalid question endpoint with a valid <contentType> and <accept>
+        Then I should receive the appropriate response for the invalid endpoint with statusCode <statusCode>
+        Examples:
+            | contentType      | accept           | statusCode | selectedNino |
+            | application/json | application/json | 403        | KE000000C    |

--- a/feature-tests/tests/resources/features/hmrcPost/hmrcAnswer-HappyPath.feature
+++ b/feature-tests/tests/resources/features/hmrcPost/hmrcAnswer-HappyPath.feature
@@ -1,33 +1,50 @@
 Feature: HMRC-KBV-POST-Answer-HappyPath.feature
 
-    @pre-merge @regression
-    Scenario Outline: Happy Path - Post request to /answer Endpoint for userId with >=3 questions over 2 questionKeys
+    @pre-merge @hmrc-answer
+    Scenario Outline: Happy Path - Post request to /answer Endpoint for nino <selectedNino> with >=3 questions over 2 questionKeys
         Given I send a new answer request to the core stub with nino value <selectedNino>
         Given I send a valid POST request with <contentType> and <accept> to the fetchQuestions endpoint with status code <statusCode>
-        When I send a GET request to the question endpoint
-        And I send a POST request to the answer endpoint with the correct answerKey
+        When I send a first GET request to the question endpoint followed by a POST request to the answer endpoint with the correct answerKey
         And I send a second GET request to the question endpoint followed by a POST request to the answer endpoint
         And I send a third GET request to the question endpoint followed by a POST request to the answer endpoint
         Then I should receive a valid response with statusCode <statusCode> from the answers endpoint
         Then I should receive a final valid response with statusCode <finalStatusCode> from the questions endpoint
-        And I should receive a VC with the correct values for a user with >=3 questions over 2 questionKey
+        And I should receive a VC with the correct values <verificationScore> for <selectedNino> with >=3 questions over 2 questionKey
         Examples:
-            | contentType      | accept           | statusCode | finalStatusCode | selectedNino |
-            | application/json | application/json | 200        | 204             | KE000000C    |
-            | application/json | application/json | 200        | 204             | AA000000A    |
-            | application/json | application/json | 200        | 204             | AA000003A    |
-            | application/json | application/json | 200        | 204             | AA000004A    |
-            | application/json | application/json | 200        | 204             | AA000005A    |
-            | application/json | application/json | 200        | 204             | AA000006A    |
+            | contentType      | accept           | statusCode | finalStatusCode | selectedNino | verificationScore     |
+            | application/json | application/json | 200        | 204             | KE000000C    | "verificationScore":2 |
+            | application/json | application/json | 200        | 204             | AA000000A    | "verificationScore":2 |
+            | application/json | application/json | 200        | 204             | AA000003A    | "verificationScore":2 |
+            | application/json | application/json | 200        | 204             | AA000004A    | "verificationScore":2 |
+            | application/json | application/json | 200        | 204             | AA000005A    | "verificationScore":2 |
+            | application/json | application/json | 200        | 204             | AA000006A    | "verificationScore":2 |
+            | application/json | application/json | 200        | 204             | AA000003I    | "verificationScore":2 |
+            | application/json | application/json | 200        | 204             | AA000003C    | "verificationScore":0 |
+            | application/json | application/json | 200        | 204             | AA000003Z    | "verificationScore":0 |
 
-    @pre-merge @post-merge
-    Scenario Outline: Happy Path - Post request to /answer Endpoint for userId with 2 questions over 2 questionKeys
+    @pre-merge @post-merge @hmrc-answer
+    Scenario Outline: Happy Path - Post request to /answer Endpoint for nino <selectedNino> with 2 questions over 2 questionKeys
         Given I send a new request to the core stub with nino value <selectedNino> for a user with 2 questions
         Given I send a valid 2 question POST request with <contentType> and <accept> to the fetchQuestions endpoint with status code <statusCode>
         When I send the first GET request to the question endpoint followed by a POST request to the answer endpoint
         And I send a second GET request to the question endpoint followed by a final POST request to the answer endpoint
         Then I should receive the final valid response with statusCode <finalStatusCode> from the questions endpoint for a user with 2 questions answered correctly
-        And I should receive a VC with the correct values for a user with 2 questions over 2 question keys
+        And I should receive a VC with the correct values <verificationScore> for <selectedNino> with 2 questions over 2 question keys
         Examples:
-            | contentType      | accept           | statusCode | finalStatusCode | selectedNino |
-            | application/json | application/json | 200        | 204             | AA000002C    |
+            | contentType      | accept           | statusCode | finalStatusCode | selectedNino | verificationScore     |
+            | application/json | application/json | 200        | 204             | AA000002A    | "verificationScore":2 |
+            | application/json | application/json | 200        | 204             | AA000002Z    | "verificationScore":0 |
+            | application/json | application/json | 200        | 204             | AA000002C    | "verificationScore":0 |
+
+
+    @pre-merge @post-merge @hmrc-answer
+    Scenario Outline: Happy Path - Post request to /answer Endpoint for nino <selectedNino> with 3 questions including 1 low confidence question
+        Given I send a new request to the core stub with nino value <selectedNino> for a user with 3 questions including 1 low confidence question
+        Given I send a POST request with <contentType> and <accept> to the fetchQuestions endpoint with status code <statusCode>
+        When I send a GET request for a medium confidence question to the question endpoint followed by a POST request to the answer endpoint
+        And I send a second GET request for a medium confidence question to the question endpoint followed by a final POST request to the answer endpoint
+        Then I should receive the final valid response with statusCode <finalStatusCode> from the questions endpoint for a user with 2 medium confidence questions
+        And I should receive a VC with the correct values <verificationScore> for <selectedNino> with 2 medium confidence questions over 2 question keys
+        Examples:
+            | contentType      | accept           | statusCode | finalStatusCode | selectedNino | verificationScore     |
+            | application/json | application/json | 200        | 204             | AA000031L    | "verificationScore":2 |

--- a/feature-tests/tests/resources/features/hmrcPost/hmrcAnswer-UnhappyPath.feature
+++ b/feature-tests/tests/resources/features/hmrcPost/hmrcAnswer-UnhappyPath.feature
@@ -1,6 +1,6 @@
 Feature: HMRC-KBV-POST-Answer-UnhappyPath.feature
 
-    @pre-merge @regression
+    @pre-merge @hmrc-answer
     Scenario Outline: Unhappy Path - Post request to /answer Endpoint - Invalid Header Values - sessionId
         Given I send a request to the core stub with nino value <selectedNino>
         Given I send a valid POST request with <contentType> and <accept> to the fetchQuestions endpoint
@@ -11,12 +11,68 @@ Feature: HMRC-KBV-POST-Answer-UnhappyPath.feature
             | contentType      | accept           | statusCode | selectedNino | session_id                           |
             | application/json | application/json | 500        | AA000002A    | 44443939-4cf4-41e9-9fee-231e16e9f382 |
 
-    @pre-merge
-    Scenario Outline: Unhappy Path - Post request to /answer Endpoint - Invalid Header Values
+    @failing-regression @hmrc-answer
+    # Confirm with Dev the expected outcome for invalid contentType headers
+    Scenario Outline: Unhappy Path - Post request to /answer Endpoint - Invalid Header Values - contentType and accept
         Given I send a valid request to the core stub with nino value <selectedNino>
-        And I send a POST request to the question endpoint with invalid <contentType> and <accept>
+        And I send a valid POST request to the fetchQuestions endpoint
+        And I send a new valid GET request to the question endpoint
+        When I send a POST request to the answer endpoint with invalid <contentType> and <accept>
         Then I should receive the appropriate response for the invalid headers value with statusCode <statusCode> and <responseMessage>
         Examples:
-            | contentType      | accept           | statusCode | selectedNino | responseMessage        |
-            | text/html        | application/json | 415        | AA000002A    | Unsupported Media Type |
-            | application/json | text/html        | 400        | AA000002A    | Invalid request body |
+            | contentType | accept           | statusCode | selectedNino | responseMessage        |
+            | text/html   | application/json | 415        | KE000000C    | Unsupported Media Type |
+
+    @pre-merge @hmrc-answer
+    Scenario Outline: Unhappy Path - Post request to /answer Endpoint - Invalid Endpoint
+        Given I send a valid request to the core stub with the selected nino value <selectedNino>
+        And I send a valid new POST request to the fetchQuestions endpoint
+        And I send a valid new GET request to the question endpoint
+        When I send a POST request to a Invalid answer endpoint with valid <contentType> and <accept>
+        Then I should receive the appropriate response for the invalid answer endpoint with statusCode <statusCode> and <responseMessage>
+        Examples:
+            | contentType | accept           | statusCode | selectedNino | responseMessage              |
+            | text/html   | application/json | 403        | AA000002A    | Missing Authentication Token |
+
+    @pre-merge @hmrc-answer
+    Scenario Outline: Unhappy Path - Post request to /answer Endpoint - Invalid Answer Body - Invalid Question Key
+        Given I send a request to the core stub with a nino value <selectedNino>
+        Given I send a new valid POST request to the fetchQuestions endpoint
+        When I send a valid GET request to the question endpoint for a valid userId
+        And I send a POST request to the question endpoint with a invalid questionKey body
+        Then I should receive the appropriate response for the invalid post body with statusCode <statusCode>
+        Examples:
+            | statusCode | selectedNino |
+            | 500        | AA000002A    |
+
+    @pre-merge @hmrc-answer
+    Scenario Outline: Unhappy Path - Post request to /answer Endpoint - Invalid Answer Body - Incorrect Question Key
+        Given I send a new request to the core stub with a nino value <selectedNino>
+        Given I send a new POST request to the fetchQuestions endpoint
+        When I send a new valid GET request to the question endpoint for a valid userId
+        And I send a POST request to the question endpoint with a incorrect questionKey body
+        Then I should receive the appropriate response for the incorrect post body with statusCode <statusCode>
+        Examples:
+            | statusCode | selectedNino |
+            | 200        | AA000002A    |
+
+    @pre-merge @hmrc-answer
+    Scenario Outline: Unhappy Path - Post request to /answer Endpoint - Invalid Answer Body - Incorrect Question Key Value
+        Given I send a new valid request to the core stub with a nino value <selectedNino>
+        Given I send a new POST request to the fetchQuestions endpoint for a valid userId
+        When I send a new GET request to the question endpoint for a valid userId
+        And I send a POST request to the question endpoint with a invalid questionKey <invalidQuestionKeyValue> value body
+        Then I should receive the appropriate response for the invalid value post body with statusCode <statusCode>
+        Examples:
+            | statusCode | selectedNino | invalidQuestionKeyValue                                                                             |
+            | 500        | AL000000S    | {"questionKey": "tc-amount","value": "400"}                                                         |
+            | 500        | AL000000S    | {"questionKey": "ita-bankaccount","value": "1234"}                                                  |
+            | 500        | AL000000S    | {"questionKey": "sa-income-from-pensions","value": "400.00"}                                        |
+            | 500        | AL000000S    | {"questionKey": "rti-p60-earnings-above-pt","value": "400.00"}                                      |
+            | 500        | AL000000S    | {"questionKey": "rti-p60-postgraduate-loan-deductions","value": "400.00"}                           |
+            | 500        | AL000000S    | {"questionKey": "rti-p60-student-loan-deductions","value": "400.00"}                                |
+            | 500        | AL000000S    | {"questionKey": "sa-payment-details","value": "\"amount\": 300.00,\"paymentDate\": \"2010-01-01\""} |
+            | 400        | AL000000S    |                                                                                                     |
+            | 400        | AL000000S    | {"questionKey": "","": ""}                                                                          |
+            | 400        | AL000000S    | {"": "","": ""}                                                                                     |
+            | 400        | AL000000S    | {"questionKeys": "tc-amount","value": "400"}                                                        |

--- a/feature-tests/tests/resources/features/hmrcPost/hmrcFetchQuestions-HappyPath.feature
+++ b/feature-tests/tests/resources/features/hmrcPost/hmrcFetchQuestions-HappyPath.feature
@@ -1,7 +1,7 @@
 Feature: HMRC-KBV-GET-FetchQuestions-HappyPath.feature
 
-    @pre-merge
-    Scenario Outline: Happy Path - Post Request to /fetchquestions Endpoint for userId
+    @pre-merge @hmrc-fetchquestions
+    Scenario Outline: Happy Path - Post Request to /fetchquestions Endpoint for userId with Nino <selectedNino>
         Given I send a new fetchquestions request to the core stub with nino value <selectedNino>
         When I send a POST request with <contentType> and <accept> to the fetchQuestions endpoint
         Then I should receive a valid response and statusCode <statusCode> from the fetchquestions endpoint
@@ -9,8 +9,8 @@ Feature: HMRC-KBV-GET-FetchQuestions-HappyPath.feature
             | contentType      | accept           | statusCode | selectedNino |
             | application/json | application/json | 200        | KE000000C    |
 
-    @pre-merge
-    Scenario Outline: Happy Path - Post Request to /fetchquestions Endpoint for same userId
+    @pre-merge @hmrc-fetchquestions
+    Scenario Outline: Happy Path - Post Request to /fetchquestions Endpoint for same userId with Nino <selectedNino
         Given I send a fetchquestions request to the core stub with nino value <selectedNino>
         When I send a POST request with <contentType> and <accept> to the fetchQuestions endpoint and receive a statusCode <statusCode>
         And I send another POST request with <contentType> and <accept> to the fetchQuestions endpoint for the same user <selectedNino>

--- a/feature-tests/tests/resources/features/hmrcPost/hmrcFetchQuestions-UnhappyPath.feature
+++ b/feature-tests/tests/resources/features/hmrcPost/hmrcFetchQuestions-UnhappyPath.feature
@@ -1,0 +1,67 @@
+Feature: HMRC-KBV-GET-FetchQuestions-UnhappyPath.feature
+
+    @pre-merge @hmrc-fetchquestions
+    Scenario Outline: Unhappy Path - Post Request to /fetchquestions Endpoint - Invalid Header Values - sessionId
+        Given I send a valid fetchquestions request to the core stub with nino value <selectedNino>
+        When I send a POST request with <contentType> and <accept> to the fetchQuestions endpoint with a invalid sessionId <session_id>
+        Then I should receive the appropriate response and statusCode <statusCode> from the fetchquestions endpoint when using invalid sessionId
+        Examples:
+            | contentType      | accept           | statusCode | selectedNino | session_id                           |
+            | application/json | application/json | 403        | KE000000C    | 44443939-4cf4-41e9-9fee-231e16e9f382 |
+
+    @failing-regression @hmrc-fetchquestions
+    # Confirm with Dev the expected outcome for invalid contentType headers
+    Scenario Outline: Unhappy Path - Post Request to /fetchquestions Endpoint - Invalid Header Values - contentType and accept
+        Given I send a new valid fetchquestions request to the core stub with nino value <selectedNino>
+        When I send a POST request with invalid headers <contentType> and <accept> to the fetchQuestions endpoint
+        Then I should receive the appropriate response and statusCode <statusCode> from the fetchquestions endpoint when using invalid headers
+        Examples:
+            | contentType      | accept           | statusCode | selectedNino |
+            | text/html        | application/json | 400        | KE000000C    |
+            | application/json | text/html        | 403        | KE000000C    |
+
+    @failing-regression @hmrc-fetchquestions
+    Scenario Outline: Unhappy Path - Post Request to /fetchquestions Endpoint - Invalid Endpoint
+        Given I send a new valid fetchquestions request to the core stub with the selected nino value <selectedNino>
+        When I send a POST request with valid headers <contentType> and <accept> to a Invalid fetchQuestions endpoint
+        Then I should receive the appropriate response and statusCode <statusCode> from the fetchquestions endpoint when using invalid endpoint
+        Examples:
+            | contentType      | accept           | statusCode | selectedNino |
+            | application/json | application/json | 403        | KE000000C    |
+
+    @pre-merge @hmrc-fetchquestions
+    Scenario Outline: Unhappy Path - Post Request to /fetchquestions Endpoint - Invalid Nino <selectedNino>
+        Given I send a new fetchquestions request to the core stub with Invalid nino value <selectedNino>
+        When I send a POST request with <contentType> and <accept> to the fetchQuestions endpoint with the invalid Nino
+        Then I should receive a valid response and statusCode <statusCode> from the fetchquestions endpoint for the invalid Nino
+        Examples:
+            | contentType      | accept           | statusCode | selectedNino |
+            | application/json | application/json | 400        | XX000000A    |
+            | application/json | application/json | 400        | KE000 000C   |
+
+    @pre-merge @hmrc-fetchquestions
+    Scenario Outline: Unhappy Path - Post Request to /fetchquestions Endpoint - Single Category Nino <selectedNino>
+        Given I send a new fetchquestions request to the core stub with a nino value <selectedNino>
+        When I send a POST request with <contentType> and <accept> to the fetchQuestions endpoint with the selected Nino
+        Then I should receive a valid response and statusCode <statusCode> from the fetchquestions endpoint for a Nino with only 1 question Category
+        Examples:
+            | contentType      | accept           | statusCode | selectedNino |
+            | application/json | application/json | 400        | CC000001C    |
+
+    @pre-merge @hmrc-fetchquestions
+    Scenario Outline: Unhappy Path - Post Request to /fetchquestions Endpoint - No Questions Nino <selectedNino>
+        Given I send a new fetchquestions request to the core stub with a no questions nino value <selectedNino>
+        When I send a POST request with <contentType> and <accept> to fetchQuestions endpoint with the selected Nino
+        Then I should receive a valid response and statusCode <statusCode> from the fetchquestions endpoint for a Nino with no questions
+        Examples:
+            | contentType      | accept           | statusCode | selectedNino |
+            | application/json | application/json | 400        | QQ000000Q    |
+
+    @pre-merge @hmrc-fetchquestions
+    Scenario Outline: Unhappy Path - Post Request to /fetchquestions Endpoint - Low Confidence Question Nino <selectedNino>
+        Given I send a new fetchquestions request to the core stub with a low confidence nino value <selectedNino>
+        When I send a POST request with <contentType> and <accept> to fetchQuestions endpoint with a Nino containing a low confidence question
+        Then I should receive a valid response and statusCode <statusCode> from the fetchquestions endpoint for a Nino a low confidence question
+        Examples:
+            | contentType      | accept           | statusCode | selectedNino |
+            | application/json | application/json | 400        | AA000021L    |

--- a/feature-tests/tests/resources/step-definitions/create-session-request-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/create-session-request-happy-path.step.ts
@@ -15,7 +15,7 @@ defineFeature(feature, (test) => {
 
   beforeEach(async () => {});
 
-  test("Happy Path - Request for user claimSet from CoreStub for Valid User", ({
+  test("Happy Path - Request for user claimSet from CoreStub for Valid User with Nino <selectedNino>", ({
     given,
   }) => {
     given(

--- a/feature-tests/tests/resources/step-definitions/get-question-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/get-question-happy-path.step.ts
@@ -20,7 +20,7 @@ defineFeature(feature, (test) => {
 
   beforeEach(async () => {});
 
-  test("Happy Path - Get request to /question Endpoint for userId", ({
+  test("Happy Path - Get request to /question Endpoint for userId with Nino <selectedNino>", ({
     given,
     then,
     when,

--- a/feature-tests/tests/resources/step-definitions/get-question-unhappy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/get-question-unhappy-path.step.ts
@@ -1,0 +1,242 @@
+import { defineFeature, loadFeature } from "jest-cucumber";
+import request from "supertest";
+import EndPoints from "../../../apiEndpoints/endpoints";
+import {
+  getSessionId,
+  generateClaimsUrl,
+  postUpdatedClaimsUrl,
+  postRequestToSessionEndpoint,
+} from "../../../utils/create-session";
+import { App } from "supertest/types";
+
+const feature = loadFeature(
+  "./tests/resources/features/hmrcGet/hmrcQuestion-UnhappyPath.feature"
+);
+
+defineFeature(feature, (test) => {
+  let getRequestToQuestionEndpoint: any;
+  let postRequestToHmrcKbvEndpoint: any;
+  let getValidSessionId: string;
+
+  beforeEach(async () => {});
+
+  test("Unhappy Path - Get request to /question Endpoint - Invalid header Values - sessionId", ({
+    given,
+    then,
+    when,
+  }) => {
+    given(
+      /^I send a new questions request to the core stub with a nino value (.*)$/,
+      async (selectedNino) => {
+        await generateClaimsUrl(selectedNino);
+        await postUpdatedClaimsUrl();
+        await postRequestToSessionEndpoint();
+        getValidSessionId = getSessionId();
+      }
+    );
+
+    when(
+      /^I send a new questions POST request with (.*) and (.*) to the fetchQuestions endpoint$/,
+      async (contentType: string, accept: string) => {
+        postRequestToHmrcKbvEndpoint = await request(
+          EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
+        )
+          .post(EndPoints.FETCH_QUESTIONS_ENDPOINT)
+          .send({})
+          .set("Content-Type", contentType)
+          .set("Accept", accept)
+          .set("session-id", getValidSessionId)
+          .buffer(true)
+          .parse((res, cb) => {
+            let data = Buffer.from("");
+            res.on("data", function (chunk) {
+              data = Buffer.concat([data, chunk]);
+            });
+            res.on("end", function () {
+              cb(null, data.toString());
+            });
+          });
+      }
+    );
+    when(
+      /^I send a GET request to the question endpoint with a invalid sessionId (.*)$/,
+      async (session_id: string) => {
+        getRequestToQuestionEndpoint = await request(
+          EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
+        )
+          .get(EndPoints.QUESTION_ENDPOINT)
+          .set("Content-Type", "application/json")
+          .set("Accept", "application/json")
+          .set("session-id", session_id)
+          .buffer(true)
+          .parse((res, cb) => {
+            let data = Buffer.from("");
+            res.on("data", function (chunk) {
+              data = Buffer.concat([data, chunk]);
+            });
+            res.on("end", function () {
+              cb(null, data.toString());
+            });
+          });
+        console.log(
+          "Question Endpoint Invalid Headers - SessionId= ",
+          JSON.stringify(getRequestToQuestionEndpoint.request, undefined, 2)
+        );
+        console.log(
+          "GET Request Questions Endpoint - Status Code= ",
+          getRequestToQuestionEndpoint.statusCode
+        );
+      }
+    );
+
+    then(
+      /^I should receive the appropriate response with statusCode (.*)$/,
+      async (statusCode: string) => {
+        expect(getRequestToQuestionEndpoint.statusCode).toEqual(
+          Number(statusCode)
+        );
+        expect(getRequestToQuestionEndpoint.body).toBeTruthy();
+      }
+    );
+  });
+
+  test("Unhappy Path - Get request to /question Endpoint - Invalid Header Values - contentType and accept", ({
+    given,
+    then,
+    when,
+    and,
+  }) => {
+    given(
+      /^I send a valid questions request to the core stub with nino value (.*)$/,
+      async (selectedNino) => {
+        await generateClaimsUrl(selectedNino);
+        await postUpdatedClaimsUrl();
+        await postRequestToSessionEndpoint();
+        getValidSessionId = getSessionId();
+      }
+    );
+
+    and(/^I send a POST request to the fetchQuestions endpoint$/, async () => {
+      postRequestToHmrcKbvEndpoint = await request(
+        EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
+      )
+        .post(EndPoints.FETCH_QUESTIONS_ENDPOINT)
+        .send({})
+        .set("Content-Type", "application/json")
+        .set("Accept", "application/json")
+        .set("session-id", getValidSessionId)
+        .buffer(true)
+        .parse((res, cb) => {
+          let data = Buffer.from("");
+          res.on("data", function (chunk) {
+            data = Buffer.concat([data, chunk]);
+          });
+          res.on("end", function () {
+            cb(null, data.toString());
+          });
+        });
+      console.log(
+        "HMRC KBV fetchquestions endpoint Status Code =",
+        postRequestToHmrcKbvEndpoint.statusCode
+      );
+    });
+
+    when(
+      /^I send a GET request to the question endpoint with a invalid (.*) and (.*)$/,
+      async (contentType: string, accept: string) => {
+        getRequestToQuestionEndpoint = await request(
+          EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
+        )
+          .get(EndPoints.QUESTION_ENDPOINT)
+          .set("Content-Type", contentType)
+          .set("Accept", accept)
+          .set("session-id", getValidSessionId)
+          .buffer(true)
+          .parse((res, cb) => {
+            let data = Buffer.from("");
+            res.on("data", function (chunk) {
+              data = Buffer.concat([data, chunk]);
+            });
+            res.on("end", function () {
+              cb(null, data.toString());
+            });
+          });
+        console.log(
+          "Question Endpoint Invalid Headers - Headers= ",
+          JSON.stringify(getRequestToQuestionEndpoint, undefined, 2)
+        );
+        console.log(
+          "GET Request Questions Endpoint - Status Code= ",
+          getRequestToQuestionEndpoint.statusCode
+        );
+      }
+    );
+
+    then(
+      /^I should receive the appropriate response for the invalid headers with statusCode (.*)$/,
+      async (statusCode: string) => {
+        expect(getRequestToQuestionEndpoint.statusCode).toEqual(
+          Number(statusCode)
+        );
+        expect(getRequestToQuestionEndpoint.body).toBeTruthy();
+      }
+    );
+  });
+
+  test("Unhappy Path - Get request to /question Endpoint - Invalid Endpoint", ({
+    given,
+    then,
+    when,
+  }) => {
+    given(
+      /^I send a valid questions request to the core stub with selected nino value (.*)$/,
+      async (selectedNino) => {
+        await generateClaimsUrl(selectedNino);
+        await postUpdatedClaimsUrl();
+        await postRequestToSessionEndpoint();
+        getValidSessionId = getSessionId();
+      }
+    );
+
+    when(
+      /^I send a GET request to a Invalid question endpoint with a valid (.*) and (.*)$/,
+      async (contentType: string, accept: string) => {
+        getRequestToQuestionEndpoint = await request(
+          EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
+        )
+          .get(EndPoints.INVALID_QUESTION_ENDPOINT)
+          .set("Content-Type", contentType)
+          .set("Accept", accept)
+          .set("session-id", getValidSessionId)
+          .buffer(true)
+          .parse((res, cb) => {
+            let data = Buffer.from("");
+            res.on("data", function (chunk) {
+              data = Buffer.concat([data, chunk]);
+            });
+            res.on("end", function () {
+              cb(null, data.toString());
+            });
+          });
+        console.log(
+          "Question Endpoint Invalid Headers - Headers= ",
+          JSON.stringify(getRequestToQuestionEndpoint, undefined, 2)
+        );
+        console.log(
+          "GET Request Questions Endpoint - Status Code= ",
+          getRequestToQuestionEndpoint.statusCode
+        );
+      }
+    );
+
+    then(
+      /^I should receive the appropriate response for the invalid endpoint with statusCode (.*)$/,
+      async (statusCode: string) => {
+        expect(getRequestToQuestionEndpoint.statusCode).toEqual(
+          Number(statusCode)
+        );
+        expect(getRequestToQuestionEndpoint.body).toBeTruthy();
+      }
+    );
+  });
+});

--- a/feature-tests/tests/resources/step-definitions/post-answer-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/post-answer-happy-path.step.ts
@@ -25,10 +25,11 @@ defineFeature(feature, (test) => {
   let postRequestToHmrcKbvEndpoint: any;
   let getValidSessionId: string;
   let questionKeyFromGetResponse: string;
+  let decrypedVcResponse: any;
 
   beforeEach(async () => {});
 
-  test("Happy Path - Post request to /answer Endpoint for userId with >=3 questions over 2 questionKeys", ({
+  test("Happy Path - Post request to /answer Endpoint for nino <selectedNino> with >=3 questions over 2 questionKeys", ({
     given,
     then,
     when,
@@ -73,34 +74,26 @@ defineFeature(feature, (test) => {
         );
       }
     );
-    when(/^I send a GET request to the question endpoint$/, async () => {
-      getRequestToQuestionEndpoint = await request(
-        EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
-      )
-        .get(EndPoints.QUESTION_ENDPOINT)
-        .set("Content-Type", "application/json")
-        .set("Accept", "application/json")
-        .set("session-id", getValidSessionId);
-      console.log(
-        "GET Request Question Endpoint - QuestionKey Response = " +
-          JSON.stringify(
-            getRequestToQuestionEndpoint.body.questionKey,
-            undefined,
-            2
-          )
-      );
-      questionKeyFromGetResponse =
-        await getRequestToQuestionEndpoint.body.questionKey;
-
-      console.log(
-        JSON.stringify(
-          `questionKeyFromGetResponse ${questionKeyFromGetResponse}`
-        )
-      );
-    });
-    and(
-      /^I send a POST request to the answer endpoint with the correct answerKey$/,
+    when(
+      /^I send a first GET request to the question endpoint followed by a POST request to the answer endpoint with the correct answerKey$/,
       async () => {
+        getRequestToQuestionEndpoint = await request(
+          EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
+        )
+          .get(EndPoints.QUESTION_ENDPOINT)
+          .set("Content-Type", "application/json")
+          .set("Accept", "application/json")
+          .set("session-id", getValidSessionId);
+        console.log(
+          "GET Request Question Endpoint - QuestionKey Response = " +
+            JSON.stringify(
+              getRequestToQuestionEndpoint.body.questionKey,
+              undefined,
+              2
+            )
+        );
+        questionKeyFromGetResponse =
+          await getRequestToQuestionEndpoint.body.questionKey;
         const postPayload = await findObjectContainingValue(
           questionKeyResponse,
           questionKeyFromGetResponse
@@ -246,17 +239,20 @@ defineFeature(feature, (test) => {
     );
 
     then(
-      /^I should receive a VC with the correct values for a user with >=3 questions over 2 questionKey$/,
-      async () => {
+      /^I should receive a VC with the correct values (.*) for (.*) with >=3 questions over 2 questionKey$/,
+      async (selectedNino: string, verificationScore: any) => {
         await getRequestAuthorisationCode();
         await getAccessTokenRequest();
         await postRequestToAccessTokenEndpoint();
-        await postRequestHmrcKbvCriVc();
+        decrypedVcResponse = await postRequestHmrcKbvCriVc();
+        expect(decrypedVcResponse).toBeTruthy();
+        expect(decrypedVcResponse).toContain(verificationScore);
+        expect(decrypedVcResponse).toContain(selectedNino);
       }
     );
   });
 
-  test("Happy Path - Post request to /answer Endpoint for userId with 2 questions over 2 questionKeys", ({
+  test("Happy Path - Post request to /answer Endpoint for nino <selectedNino> with 2 questions over 2 questionKeys", ({
     given,
     then,
     when,
@@ -398,12 +394,171 @@ defineFeature(feature, (test) => {
     );
 
     then(
-      /^I should receive a VC with the correct values for a user with 2 questions over 2 question keys$/,
-      async () => {
+      /^I should receive a VC with the correct values (.*) for (.*) with 2 questions over 2 question keys$/,
+      async (selectedNino: string, verificationScore: any) => {
         await getRequestAuthorisationCode();
         await getAccessTokenRequest();
         await postRequestToAccessTokenEndpoint();
-        await postRequestHmrcKbvCriVc();
+        decrypedVcResponse = await postRequestHmrcKbvCriVc();
+        console.log("Full VC" + decrypedVcResponse);
+        expect(decrypedVcResponse).toBeTruthy();
+        expect(decrypedVcResponse).toContain(verificationScore);
+        expect(decrypedVcResponse).toContain(selectedNino);
+      }
+    );
+  });
+
+  test("Happy Path - Post request to /answer Endpoint for nino <selectedNino> with 3 questions including 1 low confidence question", ({
+    given,
+    then,
+    when,
+    and,
+  }) => {
+    given(
+      /^I send a new request to the core stub with nino value (.*) for a user with 3 questions including 1 low confidence question$/,
+      async (selectedNino) => {
+        await generateClaimsUrl(selectedNino);
+        await postUpdatedClaimsUrl();
+        await postRequestToSessionEndpoint();
+        getValidSessionId = getSessionId();
+      }
+    );
+    given(
+      /^I send a POST request with (.*) and (.*) to the fetchQuestions endpoint with status code (.*)$/,
+      async (contentType: string, accept: string, statusCode: string) => {
+        postRequestToHmrcKbvEndpoint = await request(
+          EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
+        )
+          .post(EndPoints.FETCH_QUESTIONS_ENDPOINT)
+          .send({})
+          .set("Content-Type", contentType)
+          .set("Accept", accept)
+          .set("session-id", getValidSessionId)
+          .buffer(true)
+          .parse((res, cb) => {
+            let data = Buffer.from("");
+            res.on("data", function (chunk) {
+              data = Buffer.concat([data, chunk]);
+            });
+            res.on("end", function () {
+              cb(null, data.toString());
+            });
+          });
+        expect(postRequestToHmrcKbvEndpoint.statusCode).toEqual(
+          Number(statusCode)
+        );
+        console.log(
+          "HMRC KBV fetchquestions endpoint Status Code =",
+          postRequestToHmrcKbvEndpoint.statusCode
+        );
+      }
+    );
+    when(
+      /^I send a GET request for a medium confidence question to the question endpoint followed by a POST request to the answer endpoint$/,
+      async () => {
+        getRequestToQuestionEndpoint = await request(
+          EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
+        )
+          .get(EndPoints.QUESTION_ENDPOINT)
+          .set("Content-Type", "application/json")
+          .set("Accept", "application/json")
+          .set("session-id", getValidSessionId);
+        console.log(
+          "GET Request Question Endpoint - QuestionKey Response = " +
+            JSON.stringify(
+              getRequestToQuestionEndpoint.body.questionKey,
+              undefined,
+              2
+            )
+        );
+        questionKeyFromGetResponse =
+          await getRequestToQuestionEndpoint.body.questionKey;
+        const postPayload = await findObjectContainingValue(
+          questionKeyResponse,
+          questionKeyFromGetResponse
+        );
+        const objectProprty = Object.keys(postPayload!)[0];
+        const postQuestionKey = postPayload![objectProprty];
+        postRequestToAnswerEndpoint = await request(
+          EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
+        )
+          .post(EndPoints.ANSWER_ENDPOINT)
+          .send(postQuestionKey)
+          .set("Content-Type", "application/json")
+          .set("Accept", "application/json")
+          .set("session-id", getValidSessionId);
+        console.log("ReturnedAnswer = ", postPayload);
+      }
+    );
+
+    and(
+      /^I send a second GET request for a medium confidence question to the question endpoint followed by a final POST request to the answer endpoint$/,
+      async () => {
+        getRequestToQuestionEndpoint = await request(
+          EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
+        )
+          .get(EndPoints.QUESTION_ENDPOINT)
+          .set("Content-Type", "application/json")
+          .set("Accept", "application/json")
+          .set("session-id", getValidSessionId);
+        console.log(
+          "GET Request Question Endpoint - QuestionKey Response = " +
+            JSON.stringify(
+              getRequestToQuestionEndpoint.body.questionKey,
+              undefined,
+              2
+            )
+        );
+        questionKeyFromGetResponse =
+          await getRequestToQuestionEndpoint.body.questionKey;
+        const postPayload = await findObjectContainingValue(
+          questionKeyResponse,
+          questionKeyFromGetResponse
+        );
+        const objectProprty = Object.keys(postPayload!)[0];
+        const postQuestionKey = postPayload![objectProprty];
+        postRequestToAnswerEndpoint = await request(
+          EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
+        )
+          .post(EndPoints.ANSWER_ENDPOINT)
+          .send(postQuestionKey)
+          .set("Content-Type", "application/json")
+          .set("Accept", "application/json")
+          .set("session-id", getValidSessionId);
+        console.log("ReturnedAnswer = ", postPayload);
+      }
+    );
+
+    then(
+      /^I should receive the final valid response with statusCode (.*) from the questions endpoint for a user with 2 medium confidence questions$/,
+      async (finalStatusCode: string) => {
+        getRequestToQuestionEndpoint = await request(
+          EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
+        )
+          .get(EndPoints.QUESTION_ENDPOINT)
+          .set("Content-Type", "application/json")
+          .set("Accept", "application/json")
+          .set("session-id", getValidSessionId);
+        expect(getRequestToQuestionEndpoint.statusCode).toEqual(
+          Number(finalStatusCode)
+        );
+        console.log(
+          "Final statusCode from Questions Endpoint = " +
+            getRequestToQuestionEndpoint.statusCode
+        );
+      }
+    );
+
+    then(
+      /^I should receive a VC with the correct values (.*) for (.*) with 2 medium confidence questions over 2 question keys$/,
+      async (selectedNino: string, verificationScore: any) => {
+        await getRequestAuthorisationCode();
+        await getAccessTokenRequest();
+        await postRequestToAccessTokenEndpoint();
+        decrypedVcResponse = await postRequestHmrcKbvCriVc();
+        expect(decrypedVcResponse).toBeTruthy();
+        expect(decrypedVcResponse).toContain(verificationScore);
+        expect(decrypedVcResponse).toContain(selectedNino);
       }
     );
   });

--- a/feature-tests/tests/resources/step-definitions/post-fetchquestions-happy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/post-fetchquestions-happy-path.step.ts
@@ -19,7 +19,7 @@ defineFeature(feature, (test) => {
 
   beforeEach(async () => {});
 
-  test("Happy Path - Post Request to /fetchquestions Endpoint for userId", ({
+  test("Happy Path - Post Request to /fetchquestions Endpoint for userId with Nino <selectedNino>", ({
     given,
     when,
     then,
@@ -71,7 +71,7 @@ defineFeature(feature, (test) => {
     );
   });
 
-  test("Happy Path - Post Request to /fetchquestions Endpoint for same userId", ({
+  test("Happy Path - Post Request to /fetchquestions Endpoint for same userId with Nino <selectedNino", ({
     given,
     when,
     and,

--- a/feature-tests/tests/resources/step-definitions/post-fetchquestions-unhappy-path.step.ts
+++ b/feature-tests/tests/resources/step-definitions/post-fetchquestions-unhappy-path.step.ts
@@ -1,0 +1,419 @@
+import { defineFeature, loadFeature } from "jest-cucumber";
+import request from "supertest";
+import EndPoints from "../../../apiEndpoints/endpoints";
+import {
+  getSessionId,
+  generateClaimsUrl,
+  postUpdatedClaimsUrl,
+  postRequestToSessionEndpoint,
+} from "../../../utils/create-session";
+import { App } from "supertest/types";
+
+const feature = loadFeature(
+  "./tests/resources/features/hmrcPost/hmrcFetchQuestions-UnhappyPath.feature"
+);
+
+defineFeature(feature, (test) => {
+  let postRequestToHmrcKbvEndpoint: any;
+  let getValidSessionId: any;
+
+  beforeEach(async () => {});
+
+  test("Unhappy Path - Post Request to /fetchquestions Endpoint - Invalid Header Values - sessionId", ({
+    given,
+    when,
+    then,
+  }) => {
+    given(
+      /^I send a valid fetchquestions request to the core stub with nino value (.*)$/,
+      async (selectedNino) => {
+        await generateClaimsUrl(selectedNino);
+        await postUpdatedClaimsUrl();
+        await postRequestToSessionEndpoint();
+        getValidSessionId = getSessionId();
+      }
+    );
+    when(
+      /^I send a POST request with (.*) and (.*) to the fetchQuestions endpoint with a invalid sessionId (.*)$/,
+      async (contentType: string, accept: string, session_id: string) => {
+        postRequestToHmrcKbvEndpoint = await request(
+          EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
+        )
+          .post(EndPoints.FETCH_QUESTIONS_ENDPOINT)
+          .send({})
+          .set("Content-Type", contentType)
+          .set("Accept", accept)
+          .set("session-id", session_id)
+          .buffer(true)
+          .parse((res, cb) => {
+            let data = Buffer.from("");
+            res.on("data", function (chunk) {
+              data = Buffer.concat([data, chunk]);
+            });
+            res.on("end", function () {
+              cb(null, data.toString());
+            });
+          });
+        ("");
+        console.log(
+          "Fetch Question Invalid Headers - Session ID= ",
+          JSON.stringify(postRequestToHmrcKbvEndpoint, undefined, 2)
+        );
+      }
+    );
+
+    then(
+      /^I should receive the appropriate response and statusCode (.*) from the fetchquestions endpoint when using invalid sessionId$/,
+      async (statusCode: string) => {
+        expect(postRequestToHmrcKbvEndpoint.statusCode).toEqual(
+          Number(statusCode)
+        );
+        console.log(
+          "HMRC KBV fetchquestions endpoint Status Code= ",
+          postRequestToHmrcKbvEndpoint.statusCode
+        );
+      }
+    );
+  });
+
+  test("Unhappy Path - Post Request to /fetchquestions Endpoint - Invalid Header Values - contentType and accept", ({
+    given,
+    when,
+    then,
+  }) => {
+    given(
+      /^I send a new valid fetchquestions request to the core stub with nino value (.*)$/,
+      async (selectedNino) => {
+        await generateClaimsUrl(selectedNino);
+        await postUpdatedClaimsUrl();
+        await postRequestToSessionEndpoint();
+        getValidSessionId = getSessionId();
+      }
+    );
+    when(
+      /^I send a POST request with invalid headers (.*) and (.*) to the fetchQuestions endpoint$/,
+      async (contentType: string, accept: string) => {
+        try {
+          postRequestToHmrcKbvEndpoint = await request(
+            EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
+          )
+            .post(EndPoints.FETCH_QUESTIONS_ENDPOINT)
+            .send({})
+            .set("Content-Type", contentType)
+            .set("Accept", accept)
+            .set("session-id", getValidSessionId)
+            .buffer(true)
+            .parse((res, cb) => {
+              console.log(
+                "parse logging",
+                JSON.stringify(postRequestToHmrcKbvEndpoint, undefined, 2)
+              );
+              console.log(
+                "parse logging status",
+                postRequestToHmrcKbvEndpoint.statusCode
+              );
+              let data = Buffer.from("");
+              res.on("data", function (chunk) {
+                data = Buffer.concat([data, chunk]);
+              });
+              res.on("end", function () {
+                cb(null, data.toString());
+              });
+            });
+          console.log(
+            "Fetch Question Endpoint Invalid Headers - Headers= ",
+            JSON.stringify(postRequestToHmrcKbvEndpoint.request, undefined, 2)
+          );
+          console.log(
+            "Fetch Question Endpoint Invalid Headers - Headers= ",
+            JSON.stringify(postRequestToHmrcKbvEndpoint, undefined, 2)
+          );
+        } catch (err: any) {
+          console.log("THIS ERROR" + JSON.stringify(err)),
+            console.log("STATUS CODE" + JSON.stringify(err.status));
+        }
+      }
+    );
+
+    then(
+      /^I should receive the appropriate response and statusCode (.*) from the fetchquestions endpoint when using invalid headers$/,
+      async (statusCode: string) => {
+        expect(postRequestToHmrcKbvEndpoint.statusCode).toEqual(
+          Number(statusCode)
+        );
+        console.log(
+          "HMRC KBV fetchquestions endpoint Status Code= ",
+          postRequestToHmrcKbvEndpoint.statusCode
+        );
+      }
+    );
+  });
+
+  test("Unhappy Path - Post Request to /fetchquestions Endpoint - Invalid Endpoint", ({
+    given,
+    when,
+    then,
+  }) => {
+    given(
+      /^I send a new valid fetchquestions request to the core stub with the selected nino value (.*)$/,
+      async (selectedNino) => {
+        await generateClaimsUrl(selectedNino);
+        await postUpdatedClaimsUrl();
+        await postRequestToSessionEndpoint();
+        getValidSessionId = getSessionId();
+      }
+    );
+    when(
+      /^I send a POST request with valid headers (.*) and (.*) to a Invalid fetchQuestions endpoint$/,
+      async (contentType: string, accept: string) => {
+        postRequestToHmrcKbvEndpoint = await request(
+          EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
+        )
+          .post(EndPoints.INVALID_FETCH_QUESTIONS_ENDPOINT)
+          .send({})
+          .set("Content-Type", contentType)
+          .set("Accept", accept)
+          .set("session-id", getValidSessionId)
+          .buffer(true)
+          .parse((res, cb) => {
+            let data = Buffer.from("");
+            res.on("data", function (chunk) {
+              data = Buffer.concat([data, chunk]);
+            });
+            res.on("end", function () {
+              cb(null, data.toString());
+            });
+          });
+        console.log(
+          "Fetch Question Endpoint Invalid Headers - Headers= ",
+          JSON.stringify(postRequestToHmrcKbvEndpoint.request, undefined, 2)
+        );
+        console.log(
+          "Fetch Question Endpoint Invalid Headers - Headers= ",
+          JSON.stringify(postRequestToHmrcKbvEndpoint, undefined, 2)
+        );
+      }
+    );
+
+    then(
+      /^I should receive the appropriate response and statusCode (.*) from the fetchquestions endpoint when using invalid endpoint$/,
+      async (statusCode: string) => {
+        expect(postRequestToHmrcKbvEndpoint.statusCode).toEqual(
+          Number(statusCode)
+        );
+        console.log(
+          "HMRC KBV fetchquestions endpoint Status Code= ",
+          postRequestToHmrcKbvEndpoint.statusCode
+        );
+      }
+    );
+  });
+
+  test("Unhappy Path - Post Request to /fetchquestions Endpoint - Invalid Nino <selectedNino>", ({
+    given,
+    when,
+    then,
+  }) => {
+    given(
+      /^I send a new fetchquestions request to the core stub with Invalid nino value (.*)$/,
+      async (selectedNino) => {
+        await generateClaimsUrl(selectedNino);
+        await postUpdatedClaimsUrl();
+        await postRequestToSessionEndpoint();
+        getValidSessionId = getSessionId();
+      }
+    );
+    when(
+      /^I send a POST request with (.*) and (.*) to the fetchQuestions endpoint with the invalid Nino$/,
+      async (contentType: string, accept: string) => {
+        postRequestToHmrcKbvEndpoint = await request(
+          EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
+        )
+          .post(EndPoints.FETCH_QUESTIONS_ENDPOINT)
+          .send({})
+          .set("Content-Type", contentType)
+          .set("Accept", accept)
+          .set("session-id", getValidSessionId)
+          .buffer(true)
+          .parse((res, cb) => {
+            let data = Buffer.from("");
+            res.on("data", function (chunk) {
+              data = Buffer.concat([data, chunk]);
+            });
+            res.on("end", function () {
+              cb(null, data.toString());
+            });
+          });
+      }
+    );
+
+    then(
+      /^I should receive a valid response and statusCode (.*) from the fetchquestions endpoint for the invalid Nino$/,
+      async (statusCode: string) => {
+        expect(postRequestToHmrcKbvEndpoint.statusCode).toEqual(
+          Number(statusCode)
+        );
+        console.log(
+          "HMRC KBV fetchquestions endpoint Status Code= ",
+          postRequestToHmrcKbvEndpoint.statusCode
+        );
+      }
+    );
+  });
+
+  test("Unhappy Path - Post Request to /fetchquestions Endpoint - Single Category Nino <selectedNino>", ({
+    given,
+    when,
+    then,
+  }) => {
+    given(
+      /^I send a new fetchquestions request to the core stub with a nino value (.*)$/,
+      async (selectedNino) => {
+        await generateClaimsUrl(selectedNino);
+        await postUpdatedClaimsUrl();
+        await postRequestToSessionEndpoint();
+        getValidSessionId = getSessionId();
+      }
+    );
+    when(
+      /^I send a POST request with (.*) and (.*) to the fetchQuestions endpoint with the selected Nino$/,
+      async (contentType: string, accept: string) => {
+        postRequestToHmrcKbvEndpoint = await request(
+          EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
+        )
+          .post(EndPoints.FETCH_QUESTIONS_ENDPOINT)
+          .send({})
+          .set("Content-Type", contentType)
+          .set("Accept", accept)
+          .set("session-id", getValidSessionId)
+          .buffer(true)
+          .parse((res, cb) => {
+            let data = Buffer.from("");
+            res.on("data", function (chunk) {
+              data = Buffer.concat([data, chunk]);
+            });
+            res.on("end", function () {
+              cb(null, data.toString());
+            });
+          });
+      }
+    );
+
+    then(
+      /^I should receive a valid response and statusCode (.*) from the fetchquestions endpoint for a Nino with only 1 question Category$/,
+      async (statusCode: string) => {
+        expect(postRequestToHmrcKbvEndpoint.statusCode).toEqual(
+          Number(statusCode)
+        );
+        console.log(
+          "HMRC KBV fetchquestions endpoint Status Code= ",
+          postRequestToHmrcKbvEndpoint.statusCode
+        );
+      }
+    );
+  });
+
+  test("Unhappy Path - Post Request to /fetchquestions Endpoint - No Questions Nino <selectedNino>", ({
+    given,
+    when,
+    then,
+  }) => {
+    given(
+      /^I send a new fetchquestions request to the core stub with a no questions nino value (.*)$/,
+      async (selectedNino) => {
+        await generateClaimsUrl(selectedNino);
+        await postUpdatedClaimsUrl();
+        await postRequestToSessionEndpoint();
+        getValidSessionId = getSessionId();
+      }
+    );
+    when(
+      /^I send a POST request with (.*) and (.*) to fetchQuestions endpoint with the selected Nino$/,
+      async (contentType: string, accept: string) => {
+        postRequestToHmrcKbvEndpoint = await request(
+          EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
+        )
+          .post(EndPoints.FETCH_QUESTIONS_ENDPOINT)
+          .send({})
+          .set("Content-Type", contentType)
+          .set("Accept", accept)
+          .set("session-id", getValidSessionId)
+          .buffer(true)
+          .parse((res, cb) => {
+            let data = Buffer.from("");
+            res.on("data", function (chunk) {
+              data = Buffer.concat([data, chunk]);
+            });
+            res.on("end", function () {
+              cb(null, data.toString());
+            });
+          });
+      }
+    );
+
+    then(
+      /^I should receive a valid response and statusCode (.*) from the fetchquestions endpoint for a Nino with no questions$/,
+      async (statusCode: string) => {
+        expect(postRequestToHmrcKbvEndpoint.statusCode).toEqual(
+          Number(statusCode)
+        );
+        console.log(
+          "HMRC KBV fetchquestions endpoint Status Code= ",
+          postRequestToHmrcKbvEndpoint.statusCode
+        );
+      }
+    );
+  });
+
+  test("Unhappy Path - Post Request to /fetchquestions Endpoint - Low Confidence Question Nino <selectedNino>", ({
+    given,
+    when,
+    then,
+  }) => {
+    given(
+      /^I send a new fetchquestions request to the core stub with a low confidence nino value (.*)$/,
+      async (selectedNino) => {
+        await generateClaimsUrl(selectedNino);
+        await postUpdatedClaimsUrl();
+        await postRequestToSessionEndpoint();
+        getValidSessionId = getSessionId();
+      }
+    );
+    when(
+      /^I send a POST request with (.*) and (.*) to fetchQuestions endpoint with a Nino containing a low confidence question$/,
+      async (contentType: string, accept: string) => {
+        postRequestToHmrcKbvEndpoint = await request(
+          EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
+        )
+          .post(EndPoints.FETCH_QUESTIONS_ENDPOINT)
+          .send({})
+          .set("Content-Type", contentType)
+          .set("Accept", accept)
+          .set("session-id", getValidSessionId)
+          .buffer(true)
+          .parse((res, cb) => {
+            let data = Buffer.from("");
+            res.on("data", function (chunk) {
+              data = Buffer.concat([data, chunk]);
+            });
+            res.on("end", function () {
+              cb(null, data.toString());
+            });
+          });
+      }
+    );
+
+    then(
+      /^I should receive a valid response and statusCode (.*) from the fetchquestions endpoint for a Nino a low confidence question$/,
+      async (statusCode: string) => {
+        expect(postRequestToHmrcKbvEndpoint.statusCode).toEqual(
+          Number(statusCode)
+        );
+        console.log(
+          "HMRC KBV fetchquestions endpoint Status Code= ",
+          postRequestToHmrcKbvEndpoint.statusCode
+        );
+      }
+    );
+  });
+});

--- a/feature-tests/utils/answer_body.ts
+++ b/feature-tests/utils/answer_body.ts
@@ -56,4 +56,8 @@ export const questionKeyResponse = {
     questionKey: "sa-income-from-pensions",
     value: "163",
   },
+  ANSWER_POST_PAYLOAD_INVALID_QUESTION_KEY: {
+    questionKey: "test-test-test",
+    value: "163",
+  },
 };

--- a/feature-tests/utils/constants.ts
+++ b/feature-tests/utils/constants.ts
@@ -1,0 +1,8 @@
+export enum jwtPartsEnum {
+  HEADER,
+  PAYLOAD,
+  SIGNATURE,
+}
+
+export const ENCODING = "base64";
+export const DECODING = "utf8";

--- a/feature-tests/utils/create-session.ts
+++ b/feature-tests/utils/create-session.ts
@@ -1,7 +1,7 @@
 import EndPoints from "../apiEndpoints/endpoints";
 import request from "supertest";
 import { App } from "supertest/types";
-import { jwtPartsEnum } from "../utils/utility";
+import { getJWTPayload, getJwtSignature, decode } from "../utils/jwt-utils";
 
 let getClaimsUrl: any;
 let postClaimsUrl: any;
@@ -11,15 +11,7 @@ let getReqAuthCode: any;
 let getTokenRequest: any;
 let postHmrcKbvVCEndpoint: any;
 
-const ENCODING = "base64";
-const DECODING = "utf8";
-const getJWTPayload = (jwt: string): string =>
-  getJWTPart(jwt, jwtPartsEnum.PAYLOAD);
-const decode = (returnedVcData: string): string =>
-  Buffer.from(returnedVcData, ENCODING).toString(DECODING);
-
 export async function generateClaimsUrl(selectedNino: string) {
-  console.log("Generating Initial Claimset - ");
   const rowNumber = "&rowNumber=197";
   const ninoValue = "&nino=" + selectedNino;
   const claimsForUserUrl =
@@ -36,17 +28,13 @@ export async function generateClaimsUrl(selectedNino: string) {
     .set("Content-Type", "application/json")
     .set("Accept", "application/json");
   console.log(
-    "Initial ClaimSet: " + JSON.stringify(getClaimsUrl.text, undefined, 2)
-  );
-  console.log(
-    "Generate Initial Claimset Status Code: ",
-    getClaimsUrl.statusCode
+    "Initial ClaimSet Generated: " +
+      JSON.stringify(getClaimsUrl.text, undefined, 2)
   );
   expect(getClaimsUrl.statusCode).toEqual(Number(200));
 }
 
 export async function postUpdatedClaimsUrl() {
-  console.log("Sending Claimset payload to CoreStub");
   const claimSetBody = getClaimsUrl.text;
   postClaimsUrl = await request(EndPoints.CORE_STUB_URL)
     .post(EndPoints.PATH_POST_CLAIMS + EndPoints.CRI_ID)
@@ -64,15 +52,10 @@ export async function postUpdatedClaimsUrl() {
     "Encoded ClaimSet Response Body: " +
       JSON.stringify(postClaimsUrl.body, undefined, 2)
   );
-  console.log(
-    "Create Session Request for ClaimSet Status Code: ",
-    postClaimsUrl.statusCode
-  );
   expect(postClaimsUrl.statusCode).toEqual(Number(200));
 }
 
 export async function postRequestToSessionEndpoint() {
-  console.log("Sending Encoded Claimset to Session Endpoint");
   postSessionEndpoint = await request(
     EndPoints.PRIVATE_API_GATEWAY_URL as unknown as App
   )
@@ -81,21 +64,11 @@ export async function postRequestToSessionEndpoint() {
     .set("Content-Type", "application/json")
     .set("Accept", "application/json")
     .set("X-Forwarded-For", "123456789");
-  console.log(
-    "Request to SessionId endpoint Status Code:",
-    postSessionEndpoint.statusCode
-  );
-  console.log(
-    `Request to SessionId endpoint ${EndPoints.PRIVATE_API_GATEWAY_URL}${EndPoints.SESSION_URL} Response Body = ` +
-      JSON.stringify(postSessionEndpoint.body, undefined, 2)
-  );
   console.log("SESSION_ID = ", postSessionEndpoint.body.session_id);
-
   expect(postSessionEndpoint.statusCode).toEqual(Number(201));
 }
 
 export async function getRequestAuthorisationCode() {
-  console.log("Generating Authorisation Code");
   const state = postSessionEndpoint.body.state;
   const clientId = postClaimsUrl.body.client_id;
   const sessionId = postSessionEndpoint.body.session_id;
@@ -111,17 +84,12 @@ export async function getRequestAuthorisationCode() {
     .set("session-id", sessionId)
     .set("Content-Type", "application/json")
     .set("Accept", "application/json");
-  console.log("sessionId: ", sessionId);
+  console.log("SESSION ID: ", sessionId);
   console.log("AUTH CODE: ", getReqAuthCode.body.authorizationCode.value);
-  console.log(
-    "Request to Authorisation Code endpoint Status Code:",
-    getReqAuthCode.statusCode
-  );
   expect(getReqAuthCode.statusCode).toEqual(Number(200));
 }
 
 export async function getAccessTokenRequest() {
-  console.log("Generating Access Token Request");
   const authCode = getReqAuthCode.body.authorizationCode.value;
   const accessTokenUrl =
     EndPoints.PATH_POST_ACCESS_TOKEN +
@@ -139,11 +107,6 @@ export async function getAccessTokenRequest() {
     )
     .set("Content-Type", "application/json")
     .set("Accept", "application/json");
-  console.log("authCode: ", authCode);
-  console.log(
-    "Generate Access Token Status Code: ",
-    getTokenRequest.statusCode
-  );
   console.log(
     "Request to Access Token Endpoint Response Body: " +
       JSON.stringify(getTokenRequest.text, undefined, 2)
@@ -151,22 +114,17 @@ export async function getAccessTokenRequest() {
 }
 
 export async function postRequestToAccessTokenEndpoint() {
-  console.log("Post to Access Token Endpoint");
   postAccessTokenEndpoint = await request(EndPoints.PUBLIC_API_GATEWAY_URL)
     .post(EndPoints.PATH_ACCESS_TOKEN)
     .send(getTokenRequest.text)
     .set("Content-Type", "application/json")
     .set("Accept", "application/json");
-  console.log(
-    "Post request to access token endpoint Status Code: ",
-    postAccessTokenEndpoint.statusCode
-  );
   console.log("ACCESS TOKEN: ", postAccessTokenEndpoint.body.access_token);
-  // expect(postAccessTokenEndpoint.statusCode).toEqual(Number(201));
+  expect(postAccessTokenEndpoint.statusCode).toEqual(Number(200));
 }
 
 export async function postRequestHmrcKbvCriVc() {
-  console.log("Requesting Encrypted HMRC KBV Verifiable Credential");
+  console.log("Requesting HMRC KBV Verifiable Credential");
   const bearerToken = postAccessTokenEndpoint.body.access_token;
   postHmrcKbvVCEndpoint = await request(EndPoints.PUBLIC_API_GATEWAY_URL)
     .post(EndPoints.PATH_CREDENTIAL_ISSUE)
@@ -186,26 +144,15 @@ export async function postRequestHmrcKbvCriVc() {
     });
   expect(postHmrcKbvVCEndpoint.statusCode).toEqual(Number(200));
   const returnedVcData = postHmrcKbvVCEndpoint.body;
-  console.log("Returned Encrypted VC: ", postHmrcKbvVCEndpoint.body);
-  const vc = JSON.parse(decode(getJWTPayload(returnedVcData)));
-  console.log("Returned Decrypted VC: ", vc);
-}
-
-function getJWTPart(jwt: string, part: jwtPartsEnum): string {
-  const jwtParts = jwt.split(".");
-  if (!jwtParts || jwtParts.length != 3) {
-    throw new TypeError(
-      `The JWT is invalid. Missing parts, unable to get ${jwtPartsEnum[part]}.`
-    );
-  }
-
-  if (jwtParts[part]) {
-    return jwtParts[part] as string;
-  } else {
-    throw new TypeError(
-      `The JWT is invalid, ${jwtPartsEnum[part]} is missing.`
-    );
-  }
+  console.log("HTTP Headers", postHmrcKbvVCEndpoint.headers);
+  const vc = decode(getJWTPayload(returnedVcData));
+  const signature = getJwtSignature(returnedVcData);
+  expect(postHmrcKbvVCEndpoint.headers).toHaveProperty(
+    "content-type",
+    "application/jwt"
+  );
+  console.log("VC Body: ", vc + " VC Signature: ", signature);
+  return vc;
 }
 
 export function getSessionId() {

--- a/feature-tests/utils/jwt-utils.ts
+++ b/feature-tests/utils/jwt-utils.ts
@@ -1,0 +1,92 @@
+import { DECODING, ENCODING, jwtPartsEnum } from "../utils/constants";
+import logger from "../utils/logger";
+
+/**
+ * A function for extracting and returning the signature of a JWT.
+ * @param jwt - the JWT from which to extract the signature
+ * @returns the JWT signature
+ * @throws TypeError when the JWT is invalid or the value of the JWT signature is falsy
+ */
+export const getJwtSignature = (jwt: string): string =>
+  getJWTPart(jwt, jwtPartsEnum.SIGNATURE);
+
+/**
+ * A function for extracting and returning the payload of a JWT.
+ * @param jwt - the JWT from which to extract the payload
+ * @returns the JWT payload string
+ * @throws TypeError when the JWT is invalid or the value of the JWT payload is falsy
+ */
+export const getJWTPayload = (jwt: string): string =>
+  getJWTPart(jwt, jwtPartsEnum.PAYLOAD);
+
+/**
+ * A function for extracting and returning the header of a JWT.
+ *
+ * @param jwt - the JWT from which to extract the header
+ * @returns the JWT header string
+ * @throws TypeError when the JWT is invalid or the value of the JWT header is falsy
+ */
+export const getJWTHeader = (jwt: string): string =>
+  getJWTPart(jwt, jwtPartsEnum.HEADER);
+
+/**
+ * Helper function to decode string from Base64 encoding to UTF-8.
+ * @param base64EncodedString - the Base64 encoded string that requires decoding.
+ * @returns the decoded string as UTF-8
+ */
+export const decode = (base64EncodedString: string): string =>
+  Buffer.from(base64EncodedString, ENCODING).toString(DECODING);
+
+/**
+ * Helper function to decode and return the JWT payload as JSON object.
+ *
+ * **N.B.** This method swallows any parse errors.
+ * @param jwt - the JWT to extract the payload from.
+ * @returns The payload decoded as JSON or `undefined` if it fails to parse.
+ */
+export function decodeAndReturnPayload(jwt: string) {
+  try {
+    return JSON.parse(decode(getJWTPayload(jwt)));
+  } catch {
+    logger.warn("Unable to get JWT payload object.");
+  }
+}
+
+/**
+ * Helper function to decode and return the JWT header as JSON object.
+ *
+ * **N.B.** This method swallows any parse errors.
+ * @param jwt - the JWT to extract the header from.
+ * @returns The header decoded as JSON or `undefined` if it fails to parse.
+ */
+export function decodeAndReturnHeader(jwt: string) {
+  try {
+    return JSON.parse(decode(getJWTHeader(jwt)));
+  } catch {
+    logger.warn("Unable to get JWT header object.");
+  }
+}
+
+/**
+ * A function for extracting and returning a part of a JWT.
+ * @param jwt - a JWT from which to extract the part.
+ * @param part - the JWT part to return {@link jwtPartsEnum}
+ * @returns a JWT part as a string only. Header and Payload still need to be parsed to JSON.
+ * @throws TypeError if JWT is invalid or missing parts.
+ */
+function getJWTPart(jwt: string, part: jwtPartsEnum): string {
+  const jwtParts = jwt.split(".");
+  if (!jwtParts || jwtParts.length != 3) {
+    throw new TypeError(
+      `The JWT is invalid. Missing parts, unable to get ${jwtPartsEnum[part]}.`
+    );
+  }
+
+  if (jwtParts[part]) {
+    return jwtParts[part] as string;
+  } else {
+    throw new TypeError(
+      `The JWT is invalid, ${jwtPartsEnum[part]} is missing.`
+    );
+  }
+}

--- a/feature-tests/utils/logger.ts
+++ b/feature-tests/utils/logger.ts
@@ -1,0 +1,6 @@
+/**
+ * Instantiates the logger class and exports it for ease of use.
+ */
+import { Logger } from "@aws-lambda-powertools/logger";
+export const logger = new Logger();
+export default logger;

--- a/feature-tests/utils/utility.ts
+++ b/feature-tests/utils/utility.ts
@@ -38,9 +38,3 @@ export async function findObjectContainingValue(obj: any, searchValue: string) {
   }
   return null;
 }
-
-export enum jwtPartsEnum {
-  HEADER,
-  PAYLOAD,
-  SIGNATURE,
-}

--- a/infrastructure/public-api.yaml
+++ b/infrastructure/public-api.yaml
@@ -154,11 +154,13 @@ paths:
                 "stateMachineArn": "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-IssueCredential"
               }
         responses:
-          "200":
-            statusCode: 200
+          default:
+            statusCode: 500
             responseTemplates:
-              application/json:
-                Fn::Sub: $input.path('$').output.replace('"',"")
+              application/jwt: |
+                #set($context.responseOverride.header.Content-Type = "application/jwt")
+                #set($context.responseOverride.status = 200)
+                $input.path('$').output.replace('"',"")
 
 components:
   schemas:

--- a/lambdas/fetch-questions/src/services/filter-questions-service.ts
+++ b/lambdas/fetch-questions/src/services/filter-questions-service.ts
@@ -193,10 +193,10 @@ export class FilterQuestionsService {
 
   private captureFilteringMetrics(questions: Question[], isPre: boolean) {
     // Are metrics for Pre or Post filtering
-    let prefix: string = isPre ? "Pre" : "Post";
-    let questionCountMetric: string =
+    const prefix: string = isPre ? "Pre" : "Post";
+    const questionCountMetric: string =
       prefix + FilterQuestionsServiceMetrics.FilteringQuestionKeyCount;
-    let categoryCountMetric: string =
+    const categoryCountMetric: string =
       prefix + FilterQuestionsServiceMetrics.FilteringCategoryCount;
 
     // Question count


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-1227] Added separate method for decrypting the VC` -->

## Proposed changes
Update the feature-tests repo method to decrypt the returned VC data, move to a separate method
Add additional UnhappyPath feature tests
Update Answer Happy Path tests to validate the details of the returned VC (PersonalNumber and VerificationScore)

### What changed

Method for Decrypting JWT Payload added
Logger.ts file added
constants.ts file added
UnHappy Path featurefile and steps for fetchQuestions and Questions and Answers Added/Updated

### Why did it change

Provide stability to the Decrypt Method and allow for validation against returned VC
increase coverage of UnHappy Path Tests

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1227](https://govukverify.atlassian.net/browse/LIME-1227)

### Other considerations

Test Passing locally: 
![image](https://github.com/user-attachments/assets/4f48f1dd-34b8-4de1-bca2-ff9dcd0e0f2a)


4 tests failing, to be investigated with Devs (Invalid Header Values) 

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc. -->


[LIME-1227]: https://govukverify.atlassian.net/browse/LIME-1227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIME-1227]: https://govukverify.atlassian.net/browse/LIME-1227?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ