### PR TITLE
LIME-1204 tax year variable name fix

### DIFF
--- a/lambdas/fetch-questions/src/services/questions-retrieval-service.ts
+++ b/lambdas/fetch-questions/src/services/questions-retrieval-service.ts
@@ -186,25 +186,25 @@ export class QuestionsRetrievalService {
 
     responseQuestions.forEach(
       (question: {
-        [info: string]: { taxYearCurrent: string; taxYearPrevious: string };
+        [info: string]: { currentTaxYear: string; previousTaxYear: string };
         questionKey: any;
       }) => {
         const questionKey: string = question.questionKey;
         logger.debug(`question : ${questionKey}`);
 
-        let taxYearCurrent: string | undefined = undefined;
-        let taxYearPrevious: string | undefined = undefined;
+        let currentTaxYear: string | undefined = undefined;
+        let previousTaxYear: string | undefined = undefined;
 
         if (Object.prototype.hasOwnProperty.call(question, "info")) {
-          taxYearCurrent = question["info"].taxYearCurrent;
-          taxYearPrevious = question["info"].taxYearPrevious;
+          currentTaxYear = question["info"].currentTaxYear;
+          previousTaxYear = question["info"].previousTaxYear;
         }
 
-        logger.debug(`info taxYearCurrent: ${taxYearCurrent}`);
-        logger.debug(`info taxYearPrevious: ${taxYearPrevious}`);
+        logger.debug(`info currentTaxYear: ${currentTaxYear}`);
+        logger.debug(`info previousTaxYear: ${previousTaxYear}`);
 
         mappedQuestions.push(
-          new Question(questionKey, taxYearCurrent, taxYearPrevious)
+          new Question(questionKey, currentTaxYear, previousTaxYear)
         );
       }
     );

--- a/lambdas/fetch-questions/src/services/save-questions-service.ts
+++ b/lambdas/fetch-questions/src/services/save-questions-service.ts
@@ -75,7 +75,7 @@ export class SaveQuestionsService {
     logger.info("mappingInfo");
 
     const questionResultItemInfo: QuestionResultItemInfo =
-      new QuestionResultItemInfo(info?.taxYearCurrent, info?.taxYearPrevious);
+      new QuestionResultItemInfo(info?.currentTaxYear, info?.previousTaxYear);
     return questionResultItemInfo;
   }
 

--- a/lambdas/fetch-questions/src/types/questions-result-types.ts
+++ b/lambdas/fetch-questions/src/types/questions-result-types.ts
@@ -1,13 +1,13 @@
 export class Info {
-  readonly taxYearCurrent: string | undefined;
-  readonly taxYearPrevious: string | undefined;
+  readonly currentTaxYear: string | undefined;
+  readonly previousTaxYear: string | undefined;
 
   constructor(
-    taxYearCurrent: string | undefined,
-    taxYearPrevious: string | undefined
+    currentTaxYear: string | undefined,
+    previousTaxYear: string | undefined
   ) {
-    this.taxYearCurrent = taxYearCurrent;
-    this.taxYearPrevious = taxYearPrevious;
+    this.currentTaxYear = currentTaxYear;
+    this.previousTaxYear = previousTaxYear;
   }
 }
 
@@ -17,13 +17,13 @@ export class Question {
 
   constructor(
     questionKey: string,
-    taxYearCurrent: string | undefined,
-    taxYearPrevious: string | undefined
+    currentTaxYear: string | undefined,
+    previousTaxYear: string | undefined
   ) {
     this.questionKey = questionKey;
 
-    this.info = taxYearCurrent
-      ? new Info(taxYearCurrent, taxYearPrevious)
+    this.info = currentTaxYear
+      ? new Info(currentTaxYear, previousTaxYear)
       : undefined;
   }
 }
@@ -66,15 +66,15 @@ export class QuestionResultItem {
 }
 
 export class QuestionResultItemInfo {
-  taxYearCurrent: string | undefined;
-  taxYearPrevious: string | undefined;
+  currentTaxYear: string | undefined;
+  previousTaxYear: string | undefined;
 
   constructor(
-    taxYearCurrent: string | undefined,
-    taxYearPrevious: string | undefined
+    currentTaxYear: string | undefined,
+    previousTaxYear: string | undefined
   ) {
-    this.taxYearCurrent = taxYearCurrent;
-    this.taxYearPrevious = taxYearPrevious;
+    this.currentTaxYear = currentTaxYear;
+    this.previousTaxYear = previousTaxYear;
   }
 }
 

--- a/lambdas/fetch-questions/tests/services/questions-retrieval-service.test.ts
+++ b/lambdas/fetch-questions/tests/services/questions-retrieval-service.test.ts
@@ -93,8 +93,8 @@ describe("QuestionsRetrievalService", () => {
           {
             questionKey: "TEST-KEY-1",
             info: {
-              taxYearCurrent: "2024/25",
-              taxYearPrevious: "2023/24",
+              currentTaxYear: "2024/25",
+              previousTaxYear: "2023/24",
             },
           },
           {

--- a/lambdas/fetch-questions/tests/services/save-questions-service.test.ts
+++ b/lambdas/fetch-questions/tests/services/save-questions-service.test.ts
@@ -8,8 +8,8 @@ import {
 import { mock } from "jest-mock-extended";
 
 const questionKey = "testkey";
-const taxYearCurrent = "testTaxYearCurrent";
-const taxYearPrevious = "testTaxYearPrevious";
+const currentTaxYear = "testcurrentTaxYear";
+const previousTaxYear = "testpreviousTaxYear";
 
 describe("SaveQuestionsService", () => {
   process.env.QUESTIONS_TABLE_NAME = "QUESTIONS_TABLE_NAME";
@@ -25,7 +25,7 @@ describe("SaveQuestionsService", () => {
 
   it("should save questions", async () => {
     const questionResultItemInfo: QuestionResultItemInfo =
-      new QuestionResultItemInfo(taxYearCurrent, taxYearPrevious);
+      new QuestionResultItemInfo(currentTaxYear, previousTaxYear);
 
     const questionResultItemQuestion: QuestionResultItemQuestion =
       new QuestionResultItemQuestion(
@@ -42,7 +42,7 @@ describe("SaveQuestionsService", () => {
       questions: [questionResultItemQuestion],
     };
     const questions: Question[] = [
-      new Question(questionKey, taxYearCurrent, taxYearPrevious),
+      new Question(questionKey, currentTaxYear, previousTaxYear),
     ];
 
     const result = await service.saveQuestions(

--- a/step-functions/get-question.asl.json
+++ b/step-functions/get-question.asl.json
@@ -74,9 +74,53 @@
               "questionKey.$": "$.questionKey.S",
               "info.$": "$[?(@.info)].info.M",
               "order.$": "$.order.N",
-              "answered.$": "$.answered.Bool"
+              "answered.$": "$.answered.Bool",
+              "infoCount.$": "States.ArrayLength($[?(@.info)].info.M)",
+              "infoIsEmpty.$": "States.ArrayContains($[?(@.info)].info.M, '{}')"
             },
-            "End": true
+            "Next": "Choice"
+          },
+          "Choice": {
+            "Type": "Choice",
+            "Choices": [
+              {
+                "And": [
+                  {
+                    "Variable": "$.infoCount",
+                    "NumericGreaterThan": 0
+                  },
+                  {
+                    "Variable": "$.infoIsEmpty",
+                    "BooleanEquals": false
+                  }
+                ],
+                "Next": "Sanitise Info Array"
+              }
+            ],
+            "Default": "Remove Info Object"
+          },
+          "Sanitise Info Array": {
+            "Type": "Pass",
+            "End": true,
+            "Parameters": {
+              "questionKey.$": "$.questionKey",
+              "info": {
+                "currentTaxYear.$": "States.ArrayGetItem($[?(@.info[0].currentTaxYear)].info[0].currentTaxYear.S,0)",
+                "previousTaxYear.$": "States.ArrayGetItem($[?(@.info[0].previousTaxYear)].info[0].previousTaxYear.S,0)"
+              },
+              "order.$": "$.order",
+              "answered.$": "$.answered"
+            }
+          },
+          "Remove Info Object": {
+            "Type": "Pass",
+            "End": true,
+            "Parameters": {
+              "questionKey.$": "$.questionKey",
+              "info": [],
+              "order.$": "$.order",
+              "answered.$": "$.answered"
+            }
           }
         }
       },


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Changed taxYearCurrent to CurrentTaxYear and taxYearPrevious to previousTaxYear
Changed state machine getQuestion to account for above

### Why did it change

To align with third-party-stub

### Issue tracking


- [LIME-1204](https://govukverify.atlassian.net/browse/LIME-1204)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc. -->


[LIME-1204]: https://govukverify.atlassian.net/browse/LIME-1204?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ