### PR TITLE
LIME-1109 Fix duplicate log group creation by LoggingConfig in lambdas

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -1222,8 +1222,6 @@ Resources:
         Sourcemap: true
     Properties:
       Handler: lambdas/jwt-signer/src/jwt-signer-handler.lambdaHandler
-      LoggingConfig:
-        LogGroup: !Sub /aws/lambda/${AWS::StackName}/JwtSignerFunction
       CodeSigningConfigArn:
         !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
       Policies:
@@ -1264,8 +1262,6 @@ Resources:
     Properties:
       Handler: lambdas/answer-validation/src/answer-validation-handler.lambdaHandler
       FunctionName: !Sub "${AWS::StackName}-answer-validation"
-      LoggingConfig:
-        LogGroup: !Sub "/aws/lambda/${AWS::StackName}-AnswerValidationFunction"
       CodeSigningConfigArn:
         !If [EnforceCodeSigning, !Ref CodeSigningConfigArn, !Ref AWS::NoValue]
 


### PR DESCRIPTION
## Proposed changes

### What changed

Fix duplicate log group creation by LoggingConfig in lambdas

### Why did it change

All lambdas have a dedicated log group section and the presence of a LoggingConfig was creating a second unused loggroup.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1109](https://govukverify.atlassian.net/browse/LIME-1109)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc. -->
