### PR TITLE
LIME-1215: Updated run-tests.sh with new params for Pipeline Execution

### DIFF
--- a/feature-tests/run-tests.sh
+++ b/feature-tests/run-tests.sh
@@ -33,6 +33,22 @@ echo "STACK_NAME ${STACK_NAME}"
 
 # run tests and save the exit code
 declare test_run_result
+
+if [ "${STACK_NAME}" != "local" ]; then
+
+  PARAMETERS_NAMES=(CORE_STUB_URL CORE_STUB_PASSWORD CORE_STUB_USERNAME FRONTEND)
+  tLen=${#PARAMETERS_NAMES[@]}
+   for (( i=0; i<${tLen}; i++ ));
+  do
+    echo "/tests/$STACK_NAME/${PARAMETERS_NAMES[$i]}"
+    PARAMETER=$(aws ssm get-parameter --name "/tests/$STACK_NAME/${PARAMETERS_NAMES[$i]}" --region eu-west-2)
+    VALUE=$(echo "$PARAMETER" | jq '.Parameter.Value')
+    NAME=$(echo "$PARAMETER" | jq '.Parameter.Name' | cut -d "/" -f4 | sed 's/.$//')
+
+    eval $(echo "export ${NAME}=${VALUE}")
+  done
+fi
+
 export tagFilter=$(aws ssm get-parameter --name "/tests/${STACK_NAME}/TestTag" | jq -r ".Parameter.Value")
 if [[ -z "${tagFilter}" ]]; then
   export tagFilter="@regression"


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-1215] Updated run-tests.sh with new params for Pipeline Execution` -->

## Proposed changes

### What changed

Updated run-tests.sh file with new params

### Why did it change

To allow the test image running against the Build and Staging Pipelines to execute in AWS CodePipeline 

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1215](https://govukverify.atlassian.net/browse/LIME-1215)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc. -->


[LIME-1215]: https://govukverify.atlassian.net/browse/LIME-1215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIME-1215]: https://govukverify.atlassian.net/browse/LIME-1215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ