### PR TITLE
LIME-1215: Update DockerFile to install Chrome

### DIFF
--- a/feature-tests/Dockerfile
+++ b/feature-tests/Dockerfile
@@ -1,11 +1,16 @@
 # Set the base image.
 FROM amazonlinux:2023.5.20240708.0
+WORKDIR /
+
 RUN yum install -y gcc-c++ make jq
 RUN curl -sL https://rpm.nodesource.com/setup_lts.x | bash -
+RUN yum install -y wget
+RUN wget https://dl.google.com/linux/direct/google-chrome-stable_current_x86_64.rpm
+RUN yum install -y ./google-chrome-stable_current_x86_64.rpm
+RUN ln -s /usr/bin/google-chrome-stable /usr/bin/chromium
+
 RUN yum install -y nodejs
 RUN npm install npm -g
-
-WORKDIR /
 
 # Set up AWS CLI
 RUN curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" && \

--- a/feature-tests/tests/resources/step-definitions/ui/question-page.step.ts
+++ b/feature-tests/tests/resources/step-definitions/ui/question-page.step.ts
@@ -67,6 +67,7 @@ defineFeature(feature, (test) => {
             "&client_id=" +
             encodedClaims.client_id
         );
+        console.log("FRONTEND URL PASSED", contextPage )
       }
     );
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-1215] Update DockerFile to install Chrome` -->

## Proposed changes

### What changed

Update Docker File to include Chrome Install

### Why did it change

To enable Pipeline Tests running in Chrome-headless

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1215](https://govukverify.atlassian.net/browse/LIME-1215)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc. -->


[LIME-1215]: https://govukverify.atlassian.net/browse/LIME-1215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LIME-1215]: https://govukverify.atlassian.net/browse/LIME-1215?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ