### PR TITLE
LIME-1129: Updated package.json to run infra tests

### DIFF
--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -35,8 +35,11 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      - name: Run tests
+      - name: Run Unit tests
         run: npm run test:coverage -- --config .github/jest.config.ci.ts
+
+      - name: Run Infra tests
+        run: npm run test:infra -- --config .github/jest.config.ci.ts
 
       - name: Archive coverage results
         if: ${{ inputs.coverage-report }}


### PR DESCRIPTION
the infra tests will now be executed inside of the test:coverage package.json command, which will be picked up and run on the run-unit-tests.yml github workflow

<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed
Updated the main run-unit-tests.yml file to run the infra tests as part of its own action
<!-- Describe the changes in detail - the "what"-->

### Why did it change
To enable the infra tests to be run as part of the run-unit-tests.yml github workflow
<!-- Describe the reason these changes were made - the "why" -->

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1129](https://govukverify.atlassian.net/browse/LIME-1129)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc. -->

All Tests passed in checks for infra alarm tests:
![image](https://github.com/user-attachments/assets/bb6f650c-bdd2-43e2-9e37-d55550716814)




[LIME-1129]: https://govukverify.atlassian.net/browse/LIME-1129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ