### PR TITLE
LIME-1099 - Implement test data strategy

### DIFF
--- a/lambdas/ssm-parameters/src/types/strategy.ts
+++ b/lambdas/ssm-parameters/src/types/strategy.ts
@@ -1,7 +1,7 @@
 export enum Strategy {
-  STUB = "Stub",
-  UAT = "Uat",
-  LIVE = "Live",
+  STUB = "STUB",
+  UAT = "UAT",
+  LIVE = "LIVE",
 }
 
 export class StrategyUtil {


### PR DESCRIPTION
## Proposed changes

### What changed

	- Add Auto Parsing of JSON to SSM parameter fetches if the value contains all the strategy route strings
	- - Return the value from the Parsed JSON for the current strategy
	- - Error out if the above fails
	- Fallback to standard string value returns if the value has none of the route strings.
	- Add Unit test coverage for the above

	- Correct Strategy Enum string values to all caps to avoid ambiguity of the exact string value required

### Why did it change

To Implement test data strategy

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1099](https://govukverify.atlassian.net/browse/LIME-1099)

[LIME-1099]: https://govukverify.atlassian.net/browse/LIME-1099?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ