### PR TITLE
IPS-1097 canary deployment

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -151,56 +151,56 @@
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 102
+        "line_number": 116
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 110
+        "line_number": 124
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 118
+        "line_number": 132
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 126
+        "line_number": 140
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 134
+        "line_number": 148
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "a6f001558be9f15f42a6ddea2a1b8f7b6b914d2a",
         "is_verified": false,
-        "line_number": 143
+        "line_number": 157
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 154
+        "line_number": 176
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 178
+        "line_number": 200
       }
     ],
     "lambdas/jwt-signer/tests/test-data.ts": [
@@ -241,5 +241,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-29T16:12:36Z"
+  "generated_at": "2024-09-23T11:05:17Z"
 }

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -53,6 +53,20 @@ Parameters:
     Description: "The stack containing the TXMA infrastructure"
     Type: String
     Default: txma-infrastructure
+  LambdaCanaryDeployment:
+    Description: >
+      Canary strategy to be used with your Lambda applications please refer to documentation for configurations -
+      https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/automating-updates-to-serverless-apps.html
+    Type: String
+    Default: "AllAtOnce"
+  StepFunctionsCanaryDeployment:
+    Description: Deployment configuration for your Step Functions
+    Type: String
+    Default: ALL_AT_ONCE
+    AllowedValues:
+      - CANARY
+      - LINEAR
+      - ALL_AT_ONCE
 
 Conditions:
   # Avoid adding a standalone IsDevEnv condition
@@ -147,6 +161,14 @@ Globals:
               !Ref Environment,
               dynatraceSecretArn,
             ]
+    AutoPublishAlias: live
+    DeploymentPreference:
+      Enabled: true
+      Type: !Ref LambdaCanaryDeployment
+      Role: !GetAtt LambdaDeployRole.Arn
+      Alarms:
+        - !Ref HMRCKBVLambdaErrors
+        - !Ref HMRCKBVAPIGW5XXErrors
 
 Mappings:
   EnvironmentConfiguration:
@@ -361,6 +383,26 @@ Resources:
         - !Ref PermissionsBoundary
         - !Ref AWS::NoValue
 
+  LambdaDeployRole:
+    Type: AWS::IAM::Role
+    # checkov:skip=CKV_AWS_111: "Ensure IAM policies does not allow write access without constraints
+    # The network interface permissions can only be applied at the '*' resource level
+    Properties:
+      PermissionsBoundary: !If
+        - UsePermissionsBoundary
+        - !Ref PermissionsBoundary
+        - !Ref AWS::NoValue
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - codedeploy.eu-west-2.amazonaws.com
+            Action: "sts:AssumeRole"
+      ManagedPolicyArns:
+        - "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRoleForLambda"
+
   ####################################################################
   #                                                                  #
   # FetchQuestionsStateMachine                                       #
@@ -410,6 +452,15 @@ Resources:
             !Ref Environment,
             StateMachineLoggingLevel,
           ]
+      AutoPublishAlias: live
+      DeploymentPreference:
+        Type: !Ref StepFunctionsCanaryDeployment
+        Interval: 1
+        Percentage: 20
+        Alarms:
+          - !Ref HMRCKBVAPIGW5XXErrors
+          - !Ref HMRCKBVAPIGW5XXErrorsPrivatePercentage
+        StateMachineVersionArn: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-FetchQuestionsStateMachine:live"
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
@@ -561,6 +612,15 @@ Resources:
             !Ref Environment,
             StateMachineLoggingLevel,
           ]
+      AutoPublishAlias: live
+      DeploymentPreference:
+        Type: !Ref StepFunctionsCanaryDeployment
+        Interval: 1
+        Percentage: 20
+        Alarms:
+          - !Ref HMRCKBVAPIGW5XXErrors
+          - !Ref HMRCKBVAPIGW5XXErrorsPrivatePercentage
+        StateMachineVersionArn: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-PostAnswer:live"
       Policies:
         - LambdaInvokePolicy:
             FunctionName: !Ref SSMParametersFunction
@@ -648,6 +708,15 @@ Resources:
             !Ref Environment,
             StateMachineLoggingLevel,
           ]
+      AutoPublishAlias: live
+      DeploymentPreference:
+        Type: !Ref StepFunctionsCanaryDeployment
+        Interval: 1
+        Percentage: 20
+        Alarms:
+          - !Ref HMRCKBVAPIGW5XXErrors
+          - !Ref HMRCKBVAPIGW5XXErrorsPrivatePercentage
+        StateMachineVersionArn: !Sub "arn:aws:states:${AWS::Region}:${AWS::AccountId}:stateMachine:${AWS::StackName}-IssueCredential:live"
       Policies:
         - DynamoDBReadPolicy:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"


### PR DESCRIPTION
## Proposed changes
- enabled Lambda canary deployment

### What changed
- lambda DeploymentPreference - canary deployment
- step functions DeploymentPreference - canary deployment
- a new role for Lambda Deploy
- new param `StepFunctionsCanaryDeployment` with default value `AllAtOnce`
- new param `LambdaCanaryDeployment` with default value `ALL_AT_ONCE`


### Why did it change
- Canary deployments initiatives
-

### Issue tracking
- [IPS-1097](https://govukverify.atlassian.net/browse/IPS-1097)
- [IPS-1097](https://govukverify.atlassian.net/browse/IPS-1107)




[IPS-1097]: https://govukverify.atlassian.net/browse/IPS-1097?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ