### PR TITLE
LIME-1285 Add govuk_signin_journey_id and state machine identifiers to all lambda logs

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -203,6 +203,15 @@
         "line_number": 178
       }
     ],
+    "lambdas/dynamo-unmarshall/tests/dynamo-unmarshall-handler.test.ts": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "lambdas/dynamo-unmarshall/tests/dynamo-unmarshall-handler.test.ts",
+        "hashed_secret": "2c338392e09ef70d213f3fa9b88aae857fda4237",
+        "is_verified": false,
+        "line_number": 63
+      }
+    ],
     "lambdas/jwt-signer/tests/test-data.ts": [
       {
         "type": "Base64 High Entropy String",
@@ -241,5 +250,5 @@
       }
     ]
   },
-  "generated_at": "2024-08-29T16:12:36Z"
+  "generated_at": "2024-09-30T13:08:31Z"
 }

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -537,14 +537,16 @@ Resources:
           - !Sub "/${ParameterPrefix}/UserAgent"
           - !Sub "/${AWS::StackName}/UserAgent"
         Issuer: !Sub "/${CommonStackName}/verifiable-credential/issuer"
-        AnswersTableName: !Ref AnswersTable
-        QuestionsTableName: !Ref QuestionsTable
-        SessionTableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
+        DynamoUnmarshallArn: !GetAtt DynamoUnmarshallFunction.Arn
         SSMParametersFunctionArn: !GetAtt SSMParametersFunction.Arn
         OTGTokenFunctionArn: !GetAtt OTGTokenFunction.Arn
         AnswerValidationArn: !GetAtt AnswerValidationFunction.Arn
         SubmitAnswersArn: !GetAtt SubmitAnswerFunction.Arn
         CreateAuthCodeFunctionArn: !GetAtt CreateAuthCodeFunction.Arn
+        SessionTableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
+        PersonIdentityTableName: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
+        AnswersTableName: !Ref AnswersTable
+        QuestionsTableName: !Ref QuestionsTable
       Logging:
         Destinations:
           - CloudWatchLogsLogGroup:
@@ -563,6 +565,8 @@ Resources:
           ]
       Policies:
         - LambdaInvokePolicy:
+            FunctionName: !Ref DynamoUnmarshallFunction
+        - LambdaInvokePolicy:
             FunctionName: !Ref SSMParametersFunction
         - LambdaInvokePolicy:
             FunctionName: !Ref OTGTokenFunction
@@ -580,6 +584,8 @@ Resources:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
         - DynamoDBWritePolicy:
             TableName: !Sub "{{resolve:ssm:/${CommonStackName}/SessionTableName}}"
+        - DynamoDBReadPolicy:
+            TableName: !Sub "{{resolve:ssm:/${CommonStackName}/PersonIdentityTableName}}"
         - DynamoDBWritePolicy:
             TableName: !Ref QuestionsTable
         - DynamoDBWritePolicy:

--- a/lambdas/answer-validation/src/answer-validation-handler.ts
+++ b/lambdas/answer-validation/src/answer-validation-handler.ts
@@ -1,63 +1,155 @@
 import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
-import { Logger } from "@aws-lambda-powertools/logger";
+import { LogHelper } from "../../../lib/src/Logging/log-helper";
+import { SessionItem } from "../../../lib/src/types/common-types";
+import { SharedInputsValidator } from "../../../lib/src/util/shared-inputs-validator";
+import {
+  HandlerMetricExport,
+  MetricsProbe,
+} from "../../../lib/src/Service/metrics-probe";
+import { MetricUnit } from "@aws-lambda-powertools/metrics";
+import {
+  HandlerMetric,
+  CompletionStatus,
+} from "../../../lib/src/MetricTypes/handler-metric-types";
+import { AnswerValidationInputs } from "./answer-validation-types";
+import { Statemachine } from "../../../lib/src/Logging/log-helper-types";
 
-const logger = new Logger({ serviceName: "AnswerValidationHandler" });
+const logHelper = new LogHelper("AnswerValidationHandler");
 
 export class AnswerValidationHandler implements LambdaInterface {
+  constructor(private readonly metricsProbe: MetricsProbe) {}
+
+  @logHelper.logger.injectLambdaContext({ clearState: true })
+  @HandlerMetricExport.logMetrics({
+    throwOnEmptyMetrics: false,
+    captureColdStartMetric: true,
+  })
   public async handler(event: any, _context: unknown): Promise<object> {
-    let result: boolean = false;
+    try {
+      let result: boolean = false;
 
-    if (
-      event.key === "rti-p60-earnings-above-pt" ||
-      event.key === "rti-p60-postgraduate-loan-deductions" ||
-      event.key === "rti-p60-student-loan-deductions" ||
-      event.key === "sa-income-from-pensions"
-    ) {
-      result = poundValidation(event);
-    } else if (event.key === "sa-payment-details") {
-      result = sAPaymentValidation(event);
-    } else {
-      result = penceValidation(event);
+      const input: AnswerValidationInputs =
+        this.safeRetrieveLambdaEventInputs(event);
+
+      logHelper.setSessionItemToLogging(input.sessionItem);
+      logHelper.setStatemachineValuesToLogging(input.statemachine);
+      logHelper.info(
+        `Handling request for session ${input.sessionItem.sessionId}`
+      );
+
+      if (
+        input.key === "rti-p60-earnings-above-pt" ||
+        input.key === "rti-p60-postgraduate-loan-deductions" ||
+        input.key === "rti-p60-student-loan-deductions" ||
+        input.key === "sa-income-from-pensions"
+      ) {
+        result = poundValidation(input);
+      } else if (input.key === "sa-payment-details") {
+        result = sAPaymentValidation(input);
+      } else {
+        result = penceValidation(input);
+      }
+      logHelper.info("Validation complete");
+
+      this.metricsProbe.captureMetric(
+        HandlerMetric.CompletionStatus,
+        MetricUnit.Count,
+        CompletionStatus.OK
+      );
+
+      return { validated: result };
+    } catch (error: any) {
+      const lambdaName = AnswerValidationHandler.name;
+      const errorText: string = error.message;
+
+      const errorMessage = `${lambdaName} : ${errorText}`;
+      logHelper.error(errorMessage);
+
+      this.metricsProbe.captureMetric(
+        HandlerMetric.CompletionStatus,
+        MetricUnit.Count,
+        CompletionStatus.ERROR
+      );
+
+      // Indicate to the statemachine a lambda error has occured
+      return { error: errorMessage };
     }
-    logger.info("The answers have been successfully validated");
-    return { validated: result };
+  }
+
+  private safeRetrieveLambdaEventInputs(event: any): AnswerValidationInputs {
+    if (!event) {
+      throw new Error("input event is empty");
+    }
+
+    const key = event.key;
+    if (!key) {
+      throw new Error("key not found");
+    }
+
+    const value = event.value;
+    if (!value) {
+      throw new Error("value not found");
+    }
+
+    // Session
+    const sessionItem = event?.sessionItem;
+    if (!sessionItem) {
+      throw new Error("Session item was not provided");
+    } else {
+      // Will throw errors on failure
+      SharedInputsValidator.validateUnmarshalledSessionItem(event.sessionItem);
+    }
+
+    // State machine values for logging
+    const statemachine = event.statemachine;
+    if (!statemachine) {
+      throw new Error("Statemachine values not found");
+    }
+
+    return {
+      sessionItem: sessionItem as SessionItem,
+      statemachine: statemachine as Statemachine,
+      key: key,
+      value: value,
+    } as AnswerValidationInputs;
   }
 }
-export function poundValidation(event: any): boolean {
-  if (event.value.match(/^([0-9]{0,12})$/)) {
-    logger.info("Validation in Pounds");
+export function poundValidation(input: AnswerValidationInputs): boolean {
+  if (/^(\d{0,12})$/.exec(input.value)) {
+    logHelper.info("Validation in Pounds sucess");
     return true;
   } else {
-    logger.info("Validation in Pounds failed");
+    logHelper.info("Validation in Pounds failed");
     return false;
   }
 }
 
-export function penceValidation(event: any): boolean {
-  if (event.value.match(/^[0-9]*\.[0-9]{2}$/)) {
-    logger.info("Validation including pence");
+export function penceValidation(input: AnswerValidationInputs): boolean {
+  if (/^\d*\.\d{2}$/.exec(input.value)) {
+    logHelper.info("Validation in Pence success");
     return true;
   } else {
-    logger.info("Validation in Pence failed");
+    logHelper.info("Validation in Pence failed");
     return false;
   }
 }
 
-export function sAPaymentValidation(event: any): boolean {
-  if (event.value.length > 200) {
-    logger.info("Input is too long");
+export function sAPaymentValidation(input: AnswerValidationInputs): boolean {
+  if (input.value.length > 200) {
+    logHelper.info("Input is too long");
     return false;
   }
 
   try {
-    logger.info("Parsing Json:");
-    JSON.parse(event.value);
+    logHelper.info("Parsing Json:");
+    JSON.parse(input.value);
     return true;
   } catch (error) {
-    logger.info(`Parsing Json failed ${error}`);
+    logHelper.info(`Parsing Json failed for ${input.key} - ${error}`);
     return false;
   }
 }
 
-const handlerClass = new AnswerValidationHandler();
+const metricProbe = new MetricsProbe();
+const handlerClass = new AnswerValidationHandler(metricProbe);
 export const lambdaHandler = handlerClass.handler.bind(handlerClass);

--- a/lambdas/answer-validation/src/answer-validation-types.ts
+++ b/lambdas/answer-validation/src/answer-validation-types.ts
@@ -1,8 +1,9 @@
 import { Statemachine } from "../../../lib/src/Logging/log-helper-types";
 import { SessionItem } from "../../../lib/src/types/common-types";
 
-export interface OTGTokenInputs {
+export interface AnswerValidationInputs {
   sessionItem: SessionItem;
   statemachine: Statemachine;
-  otgApiUrl: string;
+  key: string;
+  value: string;
 }

--- a/lambdas/answer-validation/tests/answer-validation-handler.test.ts
+++ b/lambdas/answer-validation/tests/answer-validation-handler.test.ts
@@ -1,69 +1,120 @@
+import { Context } from "aws-lambda";
+import { MetricsProbe } from "../../../lib/src/Service/metrics-probe";
+import { SessionItem } from "../../../lib/src/types/common-types";
 import { AnswerValidationHandler } from "../src/answer-validation-handler";
+import { Statemachine } from "../../../lib/src/Logging/log-helper-types";
+
+jest.mock("@aws-lambda-powertools/metrics");
+jest.mock("../src/../../../lib/src/Service/metrics-probe");
 
 describe("AnswerValidationHandler", () => {
-  const handler = new AnswerValidationHandler();
+  const testSessionItem: SessionItem = {
+    expiryDate: 1234,
+    clientIpAddress: "127.0.0.1",
+    redirectUri: "http://localhost:8085/callback",
+    clientSessionId: "2d35a412-125e-423e-835e-ca66111a38a1",
+    createdDate: 1722954983024,
+    clientId: "unit-test-clientid",
+    subject: "urn:fdc:gov.uk:2022:6dab2b2d-5fcb-43a3-b682-9484db4a2ca5",
+    persistentSessionId: "6c33f1e4-70a9-41f6-a335-7bb036edd3ca",
+    attemptCount: 0,
+    sessionId: "665ed4d5-7576-4c4b-84ff-99af3a57ea64",
+    state: "7f42f0cc-1681-4455-872f-dd228103a12e",
+  };
+
+  const testStateMachineValue: Statemachine = {
+    executionId:
+      "arn:aws:states:REGION:ACCOUNT:express:STACK-LAMBDA:EXECUTIONID_PART1:EXECUTIONID_PART2",
+  };
+
+  let mockMetricsProbe = jest.mocked(MetricsProbe).prototype;
+  let answerValidationHandler: AnswerValidationHandler;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockMetricsProbe = jest.mocked(MetricsProbe).prototype;
+
+    jest.spyOn(mockMetricsProbe, "captureMetric");
+
+    answerValidationHandler = new AnswerValidationHandler(mockMetricsProbe);
+  });
 
   it("should return true for correct pound validation", async () => {
     const event = {
+      sessionItem: testSessionItem,
+      statemachine: testStateMachineValue,
       key: "rti-p60-earnings-above-pt",
       value: "123",
     };
-    const result = await handler.handler(event, null);
+    const result = await answerValidationHandler.handler(event, {} as Context);
     expect(result).toEqual({ validated: true });
   });
 
   it("should return false for incorrect pound validation", async () => {
     const event = {
+      sessionItem: testSessionItem,
+      statemachine: testStateMachineValue,
       key: "sa-income-from-pensions",
       value: "123.87",
     };
-    const result = await handler.handler(event, null);
+    const result = await answerValidationHandler.handler(event, {} as Context);
     expect(result).toEqual({ validated: false });
   });
 
   it("should return true for incorrect penny validation", async () => {
     const event = {
+      sessionItem: testSessionItem,
+      statemachine: testStateMachineValue,
       key: "rti-payslip-national-insurance",
       value: "123.87",
     };
-    const result = await handler.handler(event, null);
+    const result = await answerValidationHandler.handler(event, {} as Context);
     expect(result).toEqual({ validated: true });
   });
 
   it("should return false for incorrect penny validation", async () => {
     const event = {
+      sessionItem: testSessionItem,
+      statemachine: testStateMachineValue,
       key: "rti-payslip-income-tax",
       value: "1238.7",
     };
-    const result = await handler.handler(event, null);
+    const result = await answerValidationHandler.handler(event, {} as Context);
     expect(result).toEqual({ validated: false });
   });
 
   it("should return false for incorrect penny validation in pounds", async () => {
     const event = {
+      sessionItem: testSessionItem,
+      statemachine: testStateMachineValue,
       key: "rti-payslip-income-tax",
       value: "12387",
     };
-    const result = await handler.handler(event, null);
+    const result = await answerValidationHandler.handler(event, {} as Context);
     expect(result).toEqual({ validated: false });
   });
 
   it("should return true for correct Self Assessment validation", async () => {
     const event = {
+      sessionItem: testSessionItem,
+      statemachine: testStateMachineValue,
       key: "sa-payment-details",
       value:
         '{"questionKey": "sa-payment-details","answer": "{\\"amount\\": 300.00,\\"paymentDate\\": \\"2010-01-01\\"}"}',
     };
-    const result = await handler.handler(event, null);
+    const result = await answerValidationHandler.handler(event, {} as Context);
     expect(result).toEqual({ validated: true });
   });
 
   it("should return false for incorrect Self Assessment validation in pounds", async () => {
     const event = {
+      sessionItem: testSessionItem,
+      statemachine: testStateMachineValue,
       key: "sa-payment-details",
       value: "This is not a Json",
     };
-    const result = await handler.handler(event, null);
+    const result = await answerValidationHandler.handler(event, {} as Context);
     expect(result).toEqual({ validated: false });
   });
 });

--- a/lambdas/dynamo-unmarshall/src/dynamo-unmarshall-handler-types.ts
+++ b/lambdas/dynamo-unmarshall/src/dynamo-unmarshall-handler-types.ts
@@ -1,8 +1,9 @@
 import { Statemachine } from "../../../lib/src/Logging/log-helper-types";
 import { SessionItem } from "../../../lib/src/types/common-types";
+import { AttributeValue } from "@aws-sdk/client-dynamodb";
 
-export interface OTGTokenInputs {
+export interface DynamoUnmarshallInputs {
   sessionItem: SessionItem;
   statemachine: Statemachine;
-  otgApiUrl: string;
+  marshalledPayload: AttributeValue | Record<string, AttributeValue>;
 }

--- a/lambdas/dynamo-unmarshall/src/dynamo-unmarshall-handler.ts
+++ b/lambdas/dynamo-unmarshall/src/dynamo-unmarshall-handler.ts
@@ -1,5 +1,5 @@
 import { MetricUnit } from "@aws-lambda-powertools/metrics";
-import { Logger } from "@aws-lambda-powertools/logger";
+import { LogHelper } from "../../../lib/src/Logging/log-helper";
 import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 import { unmarshall } from "@aws-sdk/util-dynamodb";
 
@@ -13,7 +13,13 @@ import {
   CompletionStatus,
 } from "../../../lib/src/MetricTypes/handler-metric-types";
 
-const logger = new Logger({ serviceName: "DynamoUnmarshallHandler" });
+import { SharedInputsValidator } from "../../../lib/src/util/shared-inputs-validator";
+
+import { DynamoUnmarshallInputs } from "./dynamo-unmarshall-handler-types";
+import { SessionItem } from "../../../lib/src/types/common-types";
+import { Statemachine } from "../../../lib/src/Logging/log-helper-types";
+
+const logHelper = new LogHelper("DynamoUnmarshallHandler");
 
 export class DynamoUnmarshallHandler implements LambdaInterface {
   metricsProbe: MetricsProbe;
@@ -21,22 +27,26 @@ export class DynamoUnmarshallHandler implements LambdaInterface {
   constructor(metricsProbe: MetricsProbe) {
     this.metricsProbe = metricsProbe;
   }
-  @logger.injectLambdaContext({ clearState: true })
+  @logHelper.logger.injectLambdaContext({ clearState: true })
   @HandlerMetricExport.logMetrics({
     throwOnEmptyMetrics: false,
     captureColdStartMetric: true,
   })
   public async handler(event: any, _context: unknown): Promise<object> {
     try {
-      logger.debug(JSON.stringify(event));
+      logHelper.debug(JSON.stringify(event));
 
-      const marshalledPayload = event.marshalledPayload;
+      const input: DynamoUnmarshallInputs =
+        this.safeRetrieveLambdaEventInputs(event);
 
-      if (!marshalledPayload) {
-        throw new Error("Marshalled payload not found");
-      }
+      // sessionItem must be completely optional as we could be unmashalling it
+      logHelper.setSessionItemToLogging(input?.sessionItem);
+      logHelper.setStatemachineValuesToLogging(input.statemachine);
+      logHelper.info(
+        `Handling request for session ${input?.sessionItem?.sessionId}`
+      );
 
-      const unmarshalled = unmarshall(event.marshalledPayload);
+      const unmarshalled = unmarshall(input.marshalledPayload);
 
       this.metricsProbe.captureMetric(
         HandlerMetric.CompletionStatus,
@@ -50,7 +60,7 @@ export class DynamoUnmarshallHandler implements LambdaInterface {
       const errorText: string = error.message;
 
       const errorMessage = `${lambdaName} : ${errorText}`;
-      logger.error(errorMessage);
+      logHelper.error(errorMessage);
 
       this.metricsProbe.captureMetric(
         HandlerMetric.CompletionStatus,
@@ -61,6 +71,38 @@ export class DynamoUnmarshallHandler implements LambdaInterface {
       // Indicate to the statemachine a lambda error has occured
       return { error: errorMessage };
     }
+  }
+
+  private safeRetrieveLambdaEventInputs(event: any): DynamoUnmarshallInputs {
+    if (!event) {
+      throw new Error("input event is empty");
+    }
+
+    const marshalledPayload = event.marshalledPayload;
+    if (!marshalledPayload) {
+      throw new Error("Marshalled payload not found");
+    }
+
+    // A missing sessionItem cannot be an error - as this lambda is used to unmarshall it
+    const sessionItem = event?.sessionItem;
+    if (!sessionItem) {
+      logHelper.warn("Session item was not provided");
+    } else {
+      // Will throw errors on failure
+      SharedInputsValidator.validateUnmarshalledSessionItem(event.sessionItem);
+    }
+
+    // State machine values for logging
+    const statemachine = event.statemachine;
+    if (!statemachine) {
+      throw new Error("Statemachine values not found");
+    }
+
+    return {
+      sessionItem: sessionItem as SessionItem,
+      statemachine: statemachine as Statemachine,
+      marshalledPayload: marshalledPayload,
+    } as DynamoUnmarshallInputs;
   }
 }
 

--- a/lambdas/dynamo-unmarshall/tests/dynamo-unmarshall-handler.test.ts
+++ b/lambdas/dynamo-unmarshall/tests/dynamo-unmarshall-handler.test.ts
@@ -1,0 +1,216 @@
+import { Context } from "aws-lambda";
+import { MetricsProbe } from "../../../lib/src/Service/metrics-probe";
+
+import { SessionItem } from "../../../lib/src/types/common-types";
+import {
+  CompletionStatus,
+  HandlerMetric,
+} from "../../../lib/src/MetricTypes/handler-metric-types";
+import { MetricUnit } from "@aws-lambda-powertools/metrics";
+import { DynamoUnmarshallHandler } from "../src/dynamo-unmarshall-handler";
+import { Statemachine } from "../../../lib/src/Logging/log-helper-types";
+
+jest.mock("@aws-lambda-powertools/metrics");
+jest.mock("../src/../../../lib/src/Service/metrics-probe");
+
+describe("submit-answer-handler", () => {
+  let mockMetricsProbe = jest.mocked(MetricsProbe).prototype;
+
+  let dynamoUnmarshallHandler: DynamoUnmarshallHandler;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+
+    mockMetricsProbe = jest.mocked(MetricsProbe).prototype;
+    jest.spyOn(mockMetricsProbe, "captureMetric");
+
+    dynamoUnmarshallHandler = new DynamoUnmarshallHandler(mockMetricsProbe);
+  });
+
+  const marshalledSessionItem = {
+    expiryDate: {
+      N: "1234",
+    },
+    clientIpAddress: {
+      S: "127.0.0.1",
+    },
+    redirectUri: {
+      S: "http://localhost:8085/callback",
+    },
+    clientSessionId: {
+      S: "97821f72-48b9-4f97-9532-b190affc5b8a",
+    },
+    createdDate: {
+      N: "1727698707397",
+    },
+    clientId: {
+      S: "unit-test-clientid",
+    },
+    subject: {
+      S: "urn:fdc:gov.uk:2022:d416511f-160e-403a-a8f7-e92c9b983ad2",
+    },
+    persistentSessionId: {
+      S: "37181027-dfa7-4267-bd85-ea67288279e6",
+    },
+    attemptCount: {
+      N: "0",
+    },
+    sessionId: {
+      S: "3d9d00c5-52ed-44c5-9890-07eea3a266cf",
+    },
+    state: {
+      S: "kDe0EoxF-BjAR66B_Wzz_V48y0B4-fDpRM8eWCC6wao",
+    },
+  };
+
+  const mockSessionItem: SessionItem = {
+    expiryDate: 1234,
+    clientIpAddress: "127.0.0.1",
+    redirectUri: "http://localhost:8085/callback",
+    clientSessionId: "97821f72-48b9-4f97-9532-b190affc5b8a",
+    createdDate: 1727698707397,
+    clientId: "unit-test-clientid",
+    subject: "urn:fdc:gov.uk:2022:d416511f-160e-403a-a8f7-e92c9b983ad2",
+    persistentSessionId: "37181027-dfa7-4267-bd85-ea67288279e6",
+    attemptCount: 0,
+    sessionId: "3d9d00c5-52ed-44c5-9890-07eea3a266cf",
+    state: "kDe0EoxF-BjAR66B_Wzz_V48y0B4-fDpRM8eWCC6wao",
+  };
+
+  const mockInputEvent = {
+    statemachine: { executionId: "test" } as Statemachine,
+    marshalledPayload: marshalledSessionItem,
+  };
+
+  describe("happy path scenarios", () => {
+    it("should return an unmarshalled SessionItem", async () => {
+      global.fetch = jest.fn();
+
+      const result = await dynamoUnmarshallHandler.handler(
+        mockInputEvent,
+        {} as Context
+      );
+      expect(result).toEqual(mockSessionItem);
+
+      expect(mockMetricsProbe.captureMetric).toHaveBeenCalledWith(
+        HandlerMetric.CompletionStatus,
+        MetricUnit.Count,
+        CompletionStatus.OK
+      );
+    });
+
+    it("should return an unmarshalled custom Item", async () => {
+      global.fetch = jest.fn();
+
+      const result = await dynamoUnmarshallHandler.handler(
+        {
+          sessionItem: mockSessionItem,
+          statemachine: { executionId: "test" } as Statemachine,
+          marshalledPayload: {
+            SType: { S: "Test" },
+            NType: { N: 1234 },
+            BOOLType: { BOOL: true },
+          },
+        },
+        {} as Context
+      );
+      expect(result).toEqual({ SType: "Test", NType: 1234, BOOLType: true });
+
+      expect(mockMetricsProbe.captureMetric).toHaveBeenCalledWith(
+        HandlerMetric.CompletionStatus,
+        MetricUnit.Count,
+        CompletionStatus.OK
+      );
+    });
+
+    it("should return an error on failure to unmarshall", async () => {
+      global.fetch = jest.fn();
+
+      const result = await dynamoUnmarshallHandler.handler(
+        {
+          sessionItem: mockSessionItem,
+          statemachine: { executionId: "test" } as Statemachine,
+          marshalledPayload: {
+            Key: { UNIT_TEST_TYPE: "Test" },
+          },
+        },
+        {} as Context
+      );
+      expect(result).toEqual({
+        error:
+          "DynamoUnmarshallHandler : Unsupported type passed: UNIT_TEST_TYPE",
+      });
+
+      expect(mockMetricsProbe.captureMetric).toHaveBeenCalledWith(
+        HandlerMetric.CompletionStatus,
+        MetricUnit.Count,
+        CompletionStatus.ERROR
+      );
+    });
+
+    it("should return an error on no input event", async () => {
+      global.fetch = jest.fn();
+
+      const result = await dynamoUnmarshallHandler.handler(
+        undefined,
+        {} as Context
+      );
+      expect(result).toEqual({
+        error: "DynamoUnmarshallHandler : input event is empty",
+      });
+
+      expect(mockMetricsProbe.captureMetric).toHaveBeenCalledWith(
+        HandlerMetric.CompletionStatus,
+        MetricUnit.Count,
+        CompletionStatus.ERROR
+      );
+    });
+
+    it("should return an error on no input event", async () => {
+      global.fetch = jest.fn();
+
+      const result = await dynamoUnmarshallHandler.handler(
+        {
+          sessionItem: mockSessionItem,
+          statemachine: { executionId: "test" } as Statemachine,
+        },
+        {} as Context
+      );
+      expect(result).toEqual({
+        error: "DynamoUnmarshallHandler : Marshalled payload not found",
+      });
+
+      expect(mockMetricsProbe.captureMetric).toHaveBeenCalledWith(
+        HandlerMetric.CompletionStatus,
+        MetricUnit.Count,
+        CompletionStatus.ERROR
+      );
+    });
+
+    it("should return an error on no statemachine in input event", async () => {
+      global.fetch = jest.fn();
+
+      const result = await dynamoUnmarshallHandler.handler(
+        {
+          sessionItem: mockSessionItem,
+          marshalledPayload: {
+            SType: { S: "Test" },
+            NType: { N: 1234 },
+            BOOLType: { BOOL: true },
+          },
+        },
+        {} as Context
+      );
+      expect(result).toEqual({
+        error: "DynamoUnmarshallHandler : Statemachine values not found",
+      });
+
+      expect(mockMetricsProbe.captureMetric).toHaveBeenCalledWith(
+        HandlerMetric.CompletionStatus,
+        MetricUnit.Count,
+        CompletionStatus.ERROR
+      );
+    });
+  });
+});

--- a/lambdas/fetch-questions/src/types/fetch-question-types.ts
+++ b/lambdas/fetch-questions/src/types/fetch-question-types.ts
@@ -1,14 +1,15 @@
+import { Statemachine } from "../../../../lib/src/Logging/log-helper-types";
 import {
   SessionItem,
   PersonIdentityItem,
 } from "../../../../lib/src/types/common-types";
 
 export interface FetchQuestionInputs {
-  sessionId: string;
+  sessionItem: SessionItem;
+  statemachine: Statemachine;
+  personIdentityItem: PersonIdentityItem;
+  bearerToken: string;
   questionsUrl: string;
   userAgent: string;
   issuer: string;
-  bearerToken: string;
-  personIdentityItem: PersonIdentityItem;
-  sessionItem: SessionItem;
 }

--- a/lambdas/fetch-questions/tests/services/questions-retrieval-service.test.ts
+++ b/lambdas/fetch-questions/tests/services/questions-retrieval-service.test.ts
@@ -19,6 +19,7 @@ import {
   PersonIdentityItem,
   SessionItem,
 } from "../../../../lib/src/types/common-types";
+import { Statemachine } from "../../../../lib/src/Logging/log-helper-types";
 
 enum QuestionServiceMetrics {
   ResponseQuestionKeyCount = "ResponseQuestionKeyCount",
@@ -39,7 +40,7 @@ describe("QuestionsRetrievalService", () => {
 
   const issuer: string = "https//issuer.go.uk";
 
-  const mockSessionItem: SessionItem = {
+  const testSessionItem: SessionItem = {
     expiryDate: 1234,
     clientIpAddress: "127.0.0.1",
     redirectUri: "http://localhost:8085/callback",
@@ -51,7 +52,12 @@ describe("QuestionsRetrievalService", () => {
     attemptCount: 0,
     sessionId: "665ed4d5-7576-4c4b-84ff-99af3a57ea64",
     state: "7f42f0cc-1681-4455-872f-dd228103a12e",
-  } as SessionItem;
+  };
+
+  const testStateMachineValue: Statemachine = {
+    executionId:
+      "arn:aws:states:REGION:ACCOUNT:express:STACK-LAMBDA:EXECUTIONID_PART1:EXECUTIONID_PART2",
+  };
 
   const mockPersonIdentityItem: PersonIdentityItem = {
     sessionId: "testSessionId",
@@ -77,13 +83,13 @@ describe("QuestionsRetrievalService", () => {
   };
 
   const mockFetchQuestionInputs = {
-    sessionId: "SESSION_ID",
+    sessionItem: testSessionItem,
+    statemachine: testStateMachineValue,
+    personIdentityItem: mockPersonIdentityItem,
     questionsUrl: "dummyUrl",
     userAgent: "dummyUserAgent",
     issuer: issuer,
     bearerToken: "dummyBearerToken",
-    personIdentityItem: mockPersonIdentityItem,
-    sessionItem: mockSessionItem,
   } as FetchQuestionInputs;
 
   beforeEach(() => {

--- a/lambdas/issue-credential/src/types/issue-credential-types.ts
+++ b/lambdas/issue-credential/src/types/issue-credential-types.ts
@@ -1,12 +1,14 @@
+import { Statemachine } from "../../../../lib/src/Logging/log-helper-types";
 import {
   SessionItem,
   PersonIdentityItem,
 } from "../../../../lib/src/types/common-types";
 
 export interface IssueCredentialInputs {
-  bearerToken: string;
   sessionItem: SessionItem;
+  statemachine: Statemachine;
   personIdentityItem: PersonIdentityItem;
+  bearerToken: string;
   maxJwtTtl: string;
   jwtTtlUnit: string;
   issuer: string;

--- a/lambdas/jwt-signer/src/jwt-signer-inputs.ts
+++ b/lambdas/jwt-signer/src/jwt-signer-inputs.ts
@@ -1,8 +1,10 @@
 import { Statemachine } from "../../../lib/src/Logging/log-helper-types";
 import { SessionItem } from "../../../lib/src/types/common-types";
 
-export interface OTGTokenInputs {
+export interface JwtSignerInputs {
   sessionItem: SessionItem;
   statemachine: Statemachine;
-  otgApiUrl: string;
+  header: string;
+  claimsSet: string;
+  kid: string;
 }

--- a/lambdas/jwt-signer/src/signer-payload.ts
+++ b/lambdas/jwt-signer/src/signer-payload.ts
@@ -1,6 +1,0 @@
-export type SignerPayLoad = {
-  kid?: string;
-  header: string;
-  claimsSet: string;
-  govJourneyId: string;
-};

--- a/lambdas/jwt-signer/tests/jwt-signer-handler.test.ts
+++ b/lambdas/jwt-signer/tests/jwt-signer-handler.test.ts
@@ -1,7 +1,6 @@
 import { KMSClient } from "@aws-sdk/client-kms";
 import { JwtSignerHandler } from "../src/jwt-signer-handler";
 import sigFormatter from "ecdsa-sig-formatter";
-import { SignerPayLoad } from "../src/signer-payload";
 import { importJWK, jwtVerify } from "jose";
 import {
   claimsSet,
@@ -13,6 +12,13 @@ import {
   publicVerifyingJwk,
 } from "./test-data";
 import { MetricsProbe } from "../../../lib/src/Service/metrics-probe";
+import { Statemachine } from "../../../lib/src/Logging/log-helper-types";
+import { SessionItem } from "../../../lib/src/types/common-types";
+import {
+  CompletionStatus,
+  HandlerMetric,
+} from "../../../lib/src/MetricTypes/handler-metric-types";
+import { MetricUnit } from "@aws-lambda-powertools/metrics";
 
 jest.mock("@aws-lambda-powertools/metrics");
 jest.mock("../src/../../../lib/src/Service/metrics-probe");
@@ -23,23 +29,43 @@ const jwtSignerHandler: JwtSignerHandler = new JwtSignerHandler(
   mockMetricsProbe,
   kmsClient
 );
-const mockGovJourneyId = "test-government-journey-id";
 
-jest.spyOn(kmsClient, "send");
+const testSessionItem: SessionItem = {
+  expiryDate: 1234,
+  clientIpAddress: "127.0.0.1",
+  redirectUri: "http://localhost:8085/callback",
+  clientSessionId: "2d35a412-125e-423e-835e-ca66111a38a1",
+  createdDate: 1722954983024,
+  clientId: "unit-test-clientid",
+  subject: "urn:fdc:gov.uk:2022:6dab2b2d-5fcb-43a3-b682-9484db4a2ca5",
+  persistentSessionId: "6c33f1e4-70a9-41f6-a335-7bb036edd3ca",
+  attemptCount: 0,
+  sessionId: "665ed4d5-7576-4c4b-84ff-99af3a57ea64",
+  state: "7f42f0cc-1681-4455-872f-dd228103a12e",
+};
+
+const testStateMachineValue: Statemachine = {
+  executionId:
+    "arn:aws:states:REGION:ACCOUNT:express:STACK-LAMBDA:EXECUTIONID_PART1:EXECUTIONID_PART2",
+};
 
 const mockInputContext = {
   invokedFunctionArn: "test",
 };
 
+jest.spyOn(kmsClient, "send");
+
 describe("Successfully signs a JWT", () => {
-  const event: SignerPayLoad = {
-    kid,
-    header: JSON.stringify(header),
-    claimsSet: JSON.stringify(claimsSet),
-    govJourneyId: mockGovJourneyId,
-  };
   describe("With RAW signing mode", () => {
     it("Should verify a signed JWT message smaller than 4096", async () => {
+      const event = {
+        sessionItem: testSessionItem,
+        statemachine: testStateMachineValue,
+        kid: kid,
+        header: JSON.stringify(header),
+        claimsSet: JSON.stringify(claimsSet),
+      };
+
       kmsClient.send.mockImplementationOnce(() =>
         Promise.resolve({
           Signature: sigFormatter.joseToDer(joseSignature, "ES256"),
@@ -70,16 +96,23 @@ describe("Successfully signs a JWT", () => {
       );
 
       expect(payload).toStrictEqual(JSON.parse(event.claimsSet));
+
+      expect(mockMetricsProbe.captureMetric).toHaveBeenCalledWith(
+        HandlerMetric.CompletionStatus,
+        MetricUnit.Count,
+        CompletionStatus.OK
+      );
     });
   });
 
   describe("Using DIGEST signing mode", () => {
     it("Should verify a large signed JWT with claimset greater than 4096", async () => {
-      const event: SignerPayLoad = {
-        kid,
+      const event = {
+        sessionItem: testSessionItem,
+        statemachine: testStateMachineValue,
+        kid: kid,
         header: JSON.stringify(header),
         claimsSet: JSON.stringify(largeClaimsSet),
-        govJourneyId: mockGovJourneyId,
       };
       kmsClient.send.mockImplementationOnce(() =>
         Promise.resolve({
@@ -114,17 +147,28 @@ describe("Successfully signs a JWT", () => {
       );
 
       expect(payload).toStrictEqual(JSON.parse(event.claimsSet));
+
+      expect(mockMetricsProbe.captureMetric).toHaveBeenCalledWith(
+        HandlerMetric.CompletionStatus,
+        MetricUnit.Count,
+        CompletionStatus.OK
+      );
     });
   });
 });
 
 describe("Fails to sign a JWT", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
   it("Should error when signature is undefined", async () => {
-    const event: SignerPayLoad = {
-      kid,
+    const event = {
+      sessionItem: testSessionItem,
+      statemachine: testStateMachineValue,
+      kid: kid,
       header: JSON.stringify(header),
       claimsSet: JSON.stringify(claimsSet),
-      govJourneyId: mockGovJourneyId,
     };
 
     kmsClient.send.mockImplementationOnce(() =>
@@ -134,7 +178,7 @@ describe("Fails to sign a JWT", () => {
     );
 
     const lambdaResponse = await jwtSignerHandler.handler(
-      event as SignerPayLoad,
+      event,
       mockInputContext
     );
 
@@ -145,42 +189,81 @@ describe("Fails to sign a JWT", () => {
     const expectedResponse = { error: errorMessage };
 
     expect(lambdaResponse).toEqual(expectedResponse);
+
+    expect(mockMetricsProbe.captureMetric).toHaveBeenCalledWith(
+      HandlerMetric.CompletionStatus,
+      MetricUnit.Count,
+      CompletionStatus.ERROR
+    );
   });
 
   it("Should fail when key ID is missing", async () => {
-    const event: Partial<SignerPayLoad> = {
+    const event = {
+      sessionItem: testSessionItem,
+      statemachine: testStateMachineValue,
       header: JSON.stringify(header),
       claimsSet: JSON.stringify(claimsSet),
-      govJourneyId: mockGovJourneyId,
+    };
+
+    const lambdaResponse = await jwtSignerHandler.handler(
+      event,
+      mockInputContext
+    );
+
+    const lambdaName = JwtSignerHandler.name;
+    const errorText: string = "kid not found";
+    const errorMessage = `${lambdaName} : ${errorText}`;
+    const expectedResponse = { error: errorMessage };
+
+    expect(lambdaResponse).toEqual(expectedResponse);
+
+    expect(mockMetricsProbe.captureMetric).toHaveBeenCalledWith(
+      HandlerMetric.CompletionStatus,
+      MetricUnit.Count,
+      CompletionStatus.ERROR
+    );
+  });
+
+  it("Should throw an error if KMS response is not in JSON format", async () => {
+    const event = {
+      sessionItem: testSessionItem,
+      statemachine: testStateMachineValue,
+      kid: kid,
+      header: JSON.stringify(header),
+      claimsSet: JSON.stringify(claimsSet),
     };
 
     kmsClient.send.mockImplementationOnce(() =>
-      Promise.reject(
-        new Error(
-          "ValidationException: 1 validation error detected: Value null at 'keyId' failed to satisfy constraint: Member must not be null"
-        )
-      )
+      Promise.reject(new SyntaxError("Not JSON"))
     );
 
     const lambdaResponse = await jwtSignerHandler.handler(
-      event as SignerPayLoad,
+      event,
       mockInputContext
     );
 
     const lambdaName = JwtSignerHandler.name;
     const errorText: string =
-      "KMS signing error: Error: ValidationException: 1 validation error detected: Value null at 'keyId' failed to satisfy constraint: Member must not be null";
+      "KMS response is not in JSON format. SyntaxError Not JSON";
     const errorMessage = `${lambdaName} : ${errorText}`;
     const expectedResponse = { error: errorMessage };
 
     expect(lambdaResponse).toEqual(expectedResponse);
+
+    expect(mockMetricsProbe.captureMetric).toHaveBeenCalledWith(
+      HandlerMetric.CompletionStatus,
+      MetricUnit.Count,
+      CompletionStatus.ERROR
+    );
   });
 
-  it("Should throw an error if KMS response is not in JSON format", async () => {
-    const event: Partial<SignerPayLoad> = {
+  it("Should throw an error for an unknown error during signing with KMS", async () => {
+    const event = {
+      sessionItem: testSessionItem,
+      statemachine: testStateMachineValue,
+      kid: kid,
       header: JSON.stringify(header),
       claimsSet: JSON.stringify(claimsSet),
-      govJourneyId: mockGovJourneyId,
     };
 
     kmsClient.send.mockImplementationOnce(() =>
@@ -188,41 +271,22 @@ describe("Fails to sign a JWT", () => {
     );
 
     const lambdaResponse = await jwtSignerHandler.handler(
-      event as SignerPayLoad,
+      event,
       mockInputContext
     );
 
     const lambdaName = JwtSignerHandler.name;
     const errorText: string =
-      "KMS response is not in JSON format. SyntaxError: Unknown error";
+      "KMS response is not in JSON format. SyntaxError Unknown error";
     const errorMessage = `${lambdaName} : ${errorText}`;
     const expectedResponse = { error: errorMessage };
 
     expect(lambdaResponse).toEqual(expectedResponse);
-  });
 
-  it("Should throw an error for an unknown error during signing with KMS", async () => {
-    const event: Partial<SignerPayLoad> = {
-      header: JSON.stringify(header),
-      claimsSet: JSON.stringify(claimsSet),
-      govJourneyId: mockGovJourneyId,
-    };
-
-    kmsClient.send.mockImplementationOnce(() =>
-      Promise.reject({ Signature: "invalid-response" })
+    expect(mockMetricsProbe.captureMetric).toHaveBeenCalledWith(
+      HandlerMetric.CompletionStatus,
+      MetricUnit.Count,
+      CompletionStatus.ERROR
     );
-
-    const lambdaResponse = await jwtSignerHandler.handler(
-      event as SignerPayLoad,
-      mockInputContext
-    );
-
-    const lambdaName = JwtSignerHandler.name;
-    const errorText: string =
-      "An unknown error occurred while signing with KMS: [object Object]";
-    const errorMessage = `${lambdaName} : ${errorText}`;
-    const expectedResponse = { error: errorMessage };
-
-    expect(lambdaResponse).toEqual(expectedResponse);
   });
 });

--- a/lambdas/otg-token/src/otg-token-handler.ts
+++ b/lambdas/otg-token/src/otg-token-handler.ts
@@ -1,5 +1,5 @@
 import { MetricUnit } from "@aws-lambda-powertools/metrics";
-import { Logger } from "@aws-lambda-powertools/logger";
+import { LogHelper } from "../../../lib/src/Logging/log-helper";
 import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
 
 import {
@@ -12,10 +12,15 @@ import {
   CompletionStatus,
 } from "../../../lib/src/MetricTypes/handler-metric-types";
 
-import { OTGToken } from "./types/otg-token-types";
-import { OTGTokenRetrievalService } from "./services/otg-token-retrieval-service";
+import { SharedInputsValidator } from "../../../lib/src/util/shared-inputs-validator";
 
-const logger = new Logger({ serviceName: "OTGTokenHandler" });
+import { OTGToken } from "../../../lib/src/types/otg-token-types";
+import { OTGTokenRetrievalService } from "./services/otg-token-retrieval-service";
+import { OTGTokenInputs } from "./types/otg-token-types";
+import { SessionItem } from "../../../lib/src/types/common-types";
+import { Statemachine } from "../../../lib/src/Logging/log-helper-types";
+
+const logHelper = new LogHelper("OTGTokenHandler");
 
 export class OTGTokenHandler implements LambdaInterface {
   metricsProbe: MetricsProbe;
@@ -29,24 +34,23 @@ export class OTGTokenHandler implements LambdaInterface {
     this.otgTokenRetrievalService = otgTokenRetrievalService;
   }
 
-  @logger.injectLambdaContext({ clearState: true })
+  @logHelper.logger.injectLambdaContext({ clearState: true })
   @HandlerMetricExport.logMetrics({
     throwOnEmptyMetrics: false,
     captureColdStartMetric: true,
   })
   public async handler(event: any, _context: unknown): Promise<object> {
     try {
-      logger.info("handler start");
+      const input: OTGTokenInputs = this.safeRetrieveLambdaEventInputs(event);
 
-      const otgApiUrl: string = event?.parameters?.otgApiUrl?.value;
-      logger.debug(`OTG url ${otgApiUrl}`);
-
-      if (!otgApiUrl) {
-        throw new Error("otgApiUrl was not provided");
-      }
+      logHelper.setSessionItemToLogging(input.sessionItem);
+      logHelper.setStatemachineValuesToLogging(input.statemachine);
+      logHelper.info(
+        `Handling request for session ${input.sessionItem.sessionId}`
+      );
 
       const otgToken: OTGToken =
-        await this.otgTokenRetrievalService.retrieveToken(otgApiUrl);
+        await this.otgTokenRetrievalService.retrieveToken(input.otgApiUrl);
 
       this.metricsProbe.captureMetric(
         HandlerMetric.CompletionStatus,
@@ -54,7 +58,7 @@ export class OTGTokenHandler implements LambdaInterface {
         CompletionStatus.OK
       );
 
-      logger.info("Returning Token");
+      logHelper.info("Returning Token");
 
       // Token response returned to the calling statemachine
       return otgToken;
@@ -63,7 +67,7 @@ export class OTGTokenHandler implements LambdaInterface {
       const errorText: string = error.message;
 
       const errorMessage = `${lambdaName} : ${errorText}`;
-      logger.error(errorMessage);
+      logHelper.error(errorMessage);
 
       this.metricsProbe.captureMetric(
         HandlerMetric.CompletionStatus,
@@ -74,6 +78,35 @@ export class OTGTokenHandler implements LambdaInterface {
       // Indicate to the statemachine a lambda error has occured
       return { error: errorMessage };
     }
+  }
+
+  private safeRetrieveLambdaEventInputs(event: any): OTGTokenInputs {
+    if (!event) {
+      throw new Error("input event is empty");
+    }
+
+    const otgApiUrl: string = event?.parameters?.otgApiUrl?.value;
+    logHelper.debug(`OTG url ${otgApiUrl}`);
+
+    if (!otgApiUrl) {
+      throw new Error("otgApiUrl was not provided");
+    }
+
+    // Session - Will throw errors on failure
+    const sessionItem = event.sessionItem;
+    SharedInputsValidator.validateUnmarshalledSessionItem(event.sessionItem);
+
+    // State machine values for logging
+    const statemachine = event.statemachine;
+    if (!statemachine) {
+      throw new Error("Statemachine values not found");
+    }
+
+    return {
+      sessionItem: sessionItem as SessionItem,
+      statemachine: statemachine as Statemachine,
+      otgApiUrl: otgApiUrl,
+    } as OTGTokenInputs;
   }
 }
 

--- a/lambdas/otg-token/src/services/otg-token-retrieval-service.ts
+++ b/lambdas/otg-token/src/services/otg-token-retrieval-service.ts
@@ -1,5 +1,4 @@
 import { MetricUnit } from "@aws-lambda-powertools/metrics";
-import { Logger } from "@aws-lambda-powertools/logger";
 import {
   HTTPMetric,
   ResponseValidity,
@@ -9,14 +8,15 @@ import { Classification } from "../../../../lib/src/MetricTypes/metric-classific
 import { MetricsProbe } from "../../../../lib/src/Service/metrics-probe";
 import { StopWatch } from "../../../../lib/src/Service/stop-watch";
 
-import { OTGToken } from "../types/otg-token-types";
+import { OTGToken } from "../../../../lib/src/types/otg-token-types";
+import { LogHelper } from "../../../../lib/src/Logging/log-helper";
 
 enum OTGTokenRetrievalServiceMetrics {
   FailedToRetrieveOTGToken = "FailedToRetrieveOTGToken",
 }
 
 const ServiceName: string = "OTGTokenRetrievalService";
-const logger = new Logger({ serviceName: `${ServiceName}` });
+const logHelper = new LogHelper("OTGTokenRetrievalService");
 
 export class OTGTokenRetrievalService {
   metricsProbe: MetricsProbe;
@@ -32,7 +32,7 @@ export class OTGTokenRetrievalService {
   }
 
   private async performAPIRequest(otgApiUrl: string): Promise<OTGToken> {
-    logger.info("Performing API Request");
+    logHelper.info("Performing API Request");
 
     // Response Latency (Start)
     this.stopWatch.start();
@@ -44,7 +44,7 @@ export class OTGTokenRetrievalService {
         // Happy Path Response Latency
         const latency: number = this.captureResponseLatencyMetric();
 
-        logger.info(
+        logHelper.info(
           `API Response Status Code: ${response.status}, Latency : ${latency}`
         );
 
@@ -61,7 +61,7 @@ export class OTGTokenRetrievalService {
           case 200: {
             return await this.retrieveJSONResponse(response)
               .then((tokenResponse: OTGToken) => {
-                logger.debug(
+                logHelper.debug(
                   `TOKEN REPONSE - ${JSON.stringify(tokenResponse)}`
                 );
 
@@ -131,7 +131,7 @@ export class OTGTokenRetrievalService {
         // any other status code
         const errorText: string = `API Request Failed : ${error.message}`;
 
-        logger.error(`${errorText}, Latency : ${latency}`);
+        logHelper.error(`${errorText}, Latency : ${latency}`);
 
         throw new Error(errorText);
       });

--- a/lambdas/otg-token/tests/service/otg-token-retrieval-service.test.ts
+++ b/lambdas/otg-token/tests/service/otg-token-retrieval-service.test.ts
@@ -7,7 +7,7 @@ import {
 import { Classification } from "../../../../lib/src/MetricTypes/metric-classifications";
 import { MetricsProbe } from "../../../../lib/src/Service/metrics-probe";
 
-import { OTGToken } from "../../src/types/otg-token-types";
+import { OTGToken } from "../../../../lib/src/types/otg-token-types";
 import { OTGTokenRetrievalService } from "../../src/services/otg-token-retrieval-service";
 
 jest.mock("@aws-lambda-powertools/metrics");

--- a/lambdas/ssm-parameters/src/types/ssm-parameters-handler-types.ts
+++ b/lambdas/ssm-parameters/src/types/ssm-parameters-handler-types.ts
@@ -1,0 +1,8 @@
+import { Statemachine } from "../../../../lib/src/Logging/log-helper-types";
+import { SessionItem } from "../../../../lib/src/types/common-types";
+
+export interface SsmParametersInputs {
+  sessionItem: SessionItem;
+  statemachine: Statemachine;
+  requestedParameters: [string];
+}

--- a/lambdas/ssm-parameters/tests/ssm-parameters-handler.test.ts
+++ b/lambdas/ssm-parameters/tests/ssm-parameters-handler.test.ts
@@ -10,6 +10,7 @@ import {
 } from "../../../lib/src/MetricTypes/handler-metric-types";
 import { MetricUnit } from "@aws-lambda-powertools/metrics";
 import { Strategy } from "../src/types/strategy";
+import { Statemachine } from "../../../lib/src/Logging/log-helper-types";
 
 jest.mock("@aws-lambda-powertools/metrics");
 jest.mock("../src/../../../lib/src/Service/metrics-probe");
@@ -26,6 +27,11 @@ const testSessionItem: SessionItem = {
   attemptCount: 0,
   sessionId: "665ed4d5-7576-4c4b-84ff-99af3a57ea64",
   state: "7f42f0cc-1681-4455-872f-dd228103a12e",
+};
+
+const testStateMachineValue: Statemachine = {
+  executionId:
+    "arn:aws:states:REGION:ACCOUNT:express:STACK-LAMBDA:EXECUTIONID_PART1:EXECUTIONID_PART2",
 };
 
 describe("ssm-parameters-handler", () => {
@@ -110,8 +116,9 @@ describe("ssm-parameters-handler", () => {
 
       const payload = await ssmParametersHandler.handler(
         {
-          requestedParameters: testRequestedParameters,
           sessionItem: testSessionItem,
+          statemachine: testStateMachineValue,
+          requestedParameters: testRequestedParameters,
         },
         {} as Context
       );
@@ -235,8 +242,9 @@ describe("ssm-parameters-handler", () => {
 
           const payload = await ssmParametersHandler.handler(
             {
-              requestedParameters: testRequestedParameters,
               sessionItem: testSessionItem,
+              statemachine: testStateMachineValue,
+              requestedParameters: testRequestedParameters,
             },
             {} as Context
           );
@@ -259,12 +267,12 @@ describe("ssm-parameters-handler", () => {
   it("should return error when given an empty list", async () => {
     const payload = await ssmParametersHandler.handler(
       {
-        requestedParameters: [],
         sessionItem: testSessionItem,
+        statemachine: testStateMachineValue,
+        requestedParameters: [],
       },
       {} as Context
     );
-
     expect(payload).toStrictEqual({
       error: "SsmParametersHandler : requestedParameters array was empty",
     });
@@ -286,8 +294,9 @@ describe("ssm-parameters-handler", () => {
 
     const payload = await ssmParametersHandler.handler(
       {
-        requestedParameters: ["BadParameter"],
         sessionItem: testSessionItem,
+        statemachine: testStateMachineValue,
+        requestedParameters: ["BadParameter"],
       },
       {} as Context
     );
@@ -314,8 +323,9 @@ describe("ssm-parameters-handler", () => {
 
     const payload = await ssmParametersHandler.handler(
       {
-        requestedParameters: ["BadParameter", "SecondBadParameter"],
         sessionItem: testSessionItem,
+        statemachine: testStateMachineValue,
+        requestedParameters: ["BadParameter", "SecondBadParameter"],
       },
       {} as Context
     );
@@ -342,8 +352,9 @@ describe("ssm-parameters-handler", () => {
 
     const payload = await ssmParametersHandler.handler(
       {
-        requestedParameters: ["GoodParameter", "SecondBadParameter"],
         sessionItem: testSessionItem,
+        statemachine: testStateMachineValue,
+        requestedParameters: ["GoodParameter", "SecondBadParameter"],
       },
       {} as Context
     );
@@ -371,8 +382,9 @@ describe("ssm-parameters-handler", () => {
 
     const payload = await ssmParametersHandler.handler(
       {
-        requestedParameters: ["UnitTestJsonParameter"],
         sessionItem: testSessionItem,
+        statemachine: testStateMachineValue,
+        requestedParameters: ["UnitTestJsonParameter"],
       },
       {} as Context
     );
@@ -393,8 +405,9 @@ describe("ssm-parameters-handler", () => {
   it("should throw error when not given an array", async () => {
     const payload = await ssmParametersHandler.handler(
       {
-        requestedParameters: undefined,
         sessionItem: testSessionItem,
+        statemachine: testStateMachineValue,
+        requestedParameters: undefined,
       } as never,
       {} as Context
     );

--- a/lambdas/submit-answer/src/create-auth-code-handler.ts
+++ b/lambdas/submit-answer/src/create-auth-code-handler.ts
@@ -1,23 +1,99 @@
 import { LambdaInterface } from "@aws-lambda-powertools/commons/types";
-import { Logger } from "@aws-lambda-powertools/logger";
+import { LogHelper } from "../../../lib/src/Logging/log-helper";
+import {
+  HandlerMetricExport,
+  MetricsProbe,
+} from "../../../lib/src/Service/metrics-probe";
+import { SessionItem } from "../../../lib/src/types/common-types";
+import { Statemachine } from "../../../lib/src/Logging/log-helper-types";
+import { CreateAuthCodeInputs } from "./create-auth-code-types";
+import { SharedInputsValidator } from "../../../lib/src/util/shared-inputs-validator";
+import {
+  CompletionStatus,
+  HandlerMetric,
+} from "../../../lib/src/MetricTypes/handler-metric-types";
+import { MetricUnit } from "@aws-lambda-powertools/metrics";
 
-const logger = new Logger();
+const logHelper = new LogHelper("CreateAuthCodeHandler");
 const DEFAULT_AUTHORIZATION_CODE_TTL_IN_MILLIS = 600 * 1000;
 
 export class CreateAuthCodeHandler implements LambdaInterface {
-  public async handler(_event: unknown, _context: unknown): Promise<any> {
+  private readonly metricsProbe: MetricsProbe;
+
+  constructor(metricsProbe: MetricsProbe) {
+    this.metricsProbe = metricsProbe;
+  }
+
+  @logHelper.logger.injectLambdaContext({ clearState: true })
+  @HandlerMetricExport.logMetrics({
+    throwOnEmptyMetrics: false,
+    captureColdStartMetric: true,
+  })
+  public async handler(event: any, _context: unknown): Promise<any> {
     try {
-      return {
+      const input: CreateAuthCodeInputs =
+        this.safeRetrieveLambdaEventInputs(event);
+
+      logHelper.setSessionItemToLogging(input.sessionItem);
+      logHelper.setStatemachineValuesToLogging(input.statemachine);
+      logHelper.info(
+        `Handling request for session ${input.sessionItem.sessionId}`
+      );
+
+      const response = {
         authCodeExpiry: Math.floor(
           (Date.now() + DEFAULT_AUTHORIZATION_CODE_TTL_IN_MILLIS) / 1000
         ),
       };
+
+      this.metricsProbe.captureMetric(
+        HandlerMetric.CompletionStatus,
+        MetricUnit.Count,
+        CompletionStatus.OK
+      );
+
+      return response;
     } catch (error: any) {
-      logger.error("Error in CreateAuthCodeHandler: " + error.message);
-      throw error;
+      const lambdaName = CreateAuthCodeHandler.name;
+      const errorText: string = error.message;
+
+      const errorMessage = `${lambdaName} : ${errorText}`;
+      logHelper.error(errorMessage);
+
+      this.metricsProbe.captureMetric(
+        HandlerMetric.CompletionStatus,
+        MetricUnit.Count,
+        CompletionStatus.ERROR
+      );
+
+      // Indicate to the statemachine a lambda error has occured
+      return { error: errorMessage };
     }
+  }
+
+  private safeRetrieveLambdaEventInputs(event: any): CreateAuthCodeInputs {
+    if (!event) {
+      throw new Error("input event is empty");
+    }
+
+    // Session - Will throw errors on failure
+    const sessionItem = event.sessionItem;
+    SharedInputsValidator.validateUnmarshalledSessionItem(event.sessionItem);
+
+    // State machine values for logging
+    const statemachine = event.statemachine;
+    if (!statemachine) {
+      throw new Error("Statemachine values not found");
+    }
+
+    return {
+      sessionItem: sessionItem as SessionItem,
+      statemachine: statemachine as Statemachine,
+    } as CreateAuthCodeInputs;
   }
 }
 
-const handlerClass = new CreateAuthCodeHandler();
+// Handler export
+const metricProbe = new MetricsProbe();
+const handlerClass = new CreateAuthCodeHandler(metricProbe);
 export const lambdaHandler = handlerClass.handler.bind(handlerClass);

--- a/lambdas/submit-answer/src/create-auth-code-types.ts
+++ b/lambdas/submit-answer/src/create-auth-code-types.ts
@@ -1,8 +1,7 @@
 import { Statemachine } from "../../../lib/src/Logging/log-helper-types";
 import { SessionItem } from "../../../lib/src/types/common-types";
 
-export interface OTGTokenInputs {
+export interface CreateAuthCodeInputs {
   sessionItem: SessionItem;
   statemachine: Statemachine;
-  otgApiUrl: string;
 }

--- a/lambdas/submit-answer/src/types/submit-answer-types.ts
+++ b/lambdas/submit-answer/src/types/submit-answer-types.ts
@@ -1,0 +1,19 @@
+import { SessionItem } from "../../../../lib/src/types/common-types";
+import { OTGToken } from "../../../../lib/src/types/otg-token-types";
+import { Statemachine } from "../../../../lib/src/Logging/log-helper-types";
+
+export interface SubmitAnswerInputs {
+  sessionItem: SessionItem;
+  statemachine: Statemachine;
+  nino: string;
+  savedAnswersItem: SavedAnswersItem;
+  parameters: any;
+  otgToken: OTGToken;
+}
+
+export interface SavedAnswersItem {
+  expiryDate: number;
+  answers: [questionKey: string, questionKey: string];
+  correlationId: string;
+  sessionId: string;
+}

--- a/lambdas/submit-answer/tests/create-auth-code-handler.test.ts
+++ b/lambdas/submit-answer/tests/create-auth-code-handler.test.ts
@@ -1,22 +1,74 @@
 import { Context } from "aws-lambda";
 import { CreateAuthCodeHandler } from "../src/create-auth-code-handler";
+import { Statemachine } from "../../../lib/src/Logging/log-helper-types";
+import { SessionItem } from "../../../lib/src/types/common-types";
+import { MetricsProbe } from "../../../lib/src/Service/metrics-probe";
+import { MetricUnit } from "@aws-lambda-powertools/metrics";
+import {
+  CompletionStatus,
+  HandlerMetric,
+} from "../../../lib/src/MetricTypes/handler-metric-types";
+
+jest.mock("@aws-lambda-powertools/metrics");
+jest.mock("../src/../../../lib/src/Service/metrics-probe");
+
+const testSessionItem: SessionItem = {
+  expiryDate: 1234,
+  clientIpAddress: "127.0.0.1",
+  redirectUri: "http://localhost:8085/callback",
+  clientSessionId: "2d35a412-125e-423e-835e-ca66111a38a1",
+  createdDate: 1722954983024,
+  clientId: "unit-test-clientid",
+  subject: "urn:fdc:gov.uk:2022:6dab2b2d-5fcb-43a3-b682-9484db4a2ca5",
+  persistentSessionId: "6c33f1e4-70a9-41f6-a335-7bb036edd3ca",
+  attemptCount: 0,
+  sessionId: "665ed4d5-7576-4c4b-84ff-99af3a57ea64",
+  state: "7f42f0cc-1681-4455-872f-dd228103a12e",
+};
+
+const testStateMachineValue: Statemachine = {
+  executionId:
+    "arn:aws:states:REGION:ACCOUNT:express:STACK-LAMBDA:EXECUTIONID_PART1:EXECUTIONID_PART2",
+};
 
 describe("create-auth-code-handler", () => {
+  let mockMetricsProbe = jest.mocked(MetricsProbe).prototype;
+  let createAuthCodeHandler: CreateAuthCodeHandler;
+
   beforeEach(() => {
     jest.clearAllMocks();
-    jest.resetAllMocks();
+
+    // Reset due to test changing this
+    testSessionItem.clientId = "unit-test-clientid";
+
+    mockMetricsProbe = jest.mocked(MetricsProbe).prototype;
+
+    jest.spyOn(mockMetricsProbe, "captureMetric");
+
+    createAuthCodeHandler = new CreateAuthCodeHandler(mockMetricsProbe);
   });
 
   it("should return an expiry 10 minutes after Date.now()", async () => {
     const mayThirtyOne2021 = 1622502000000;
     jest.spyOn(Date, "now").mockReturnValue(mayThirtyOne2021);
 
-    const handler = new CreateAuthCodeHandler();
-    const result = await handler.handler({} as unknown, {} as Context);
+    const result = await createAuthCodeHandler.handler(
+      {
+        sessionItem: testSessionItem,
+        statemachine: testStateMachineValue,
+      } as unknown,
+      {} as Context
+    );
     const mayThirtyOne2021Plus10MinsInSeconds = 1622502600;
 
     expect(result).toEqual({
       authCodeExpiry: mayThirtyOne2021Plus10MinsInSeconds,
     });
+
+    expect(mockMetricsProbe.captureMetric).toHaveBeenCalledWith(
+      HandlerMetric.CompletionStatus,
+      MetricUnit.Count,
+      CompletionStatus.OK
+    );
   });
 });

--- a/lambdas/submit-answer/tsconfig.json
+++ b/lambdas/submit-answer/tsconfig.json
@@ -15,5 +15,5 @@
     "noImplicitAny": true
   },
   "exclude": ["node_modules", "build", "coverage"],
-  "include": ["src", "tests"]
+  "include": ["src", "tests", "../../lib/src/util/shared-inputs-validator.ts"]
 }

--- a/lib/src/Logging/log-helper-types.ts
+++ b/lib/src/Logging/log-helper-types.ts
@@ -1,0 +1,3 @@
+export interface Statemachine {
+  executionId: string;
+}

--- a/lib/src/Logging/log-helper.ts
+++ b/lib/src/Logging/log-helper.ts
@@ -1,5 +1,11 @@
 import { Logger } from "@aws-lambda-powertools/logger";
 import { SessionItem } from "../types/common-types";
+import { Statemachine } from "./log-helper-types";
+
+const EXPECTED_EXECUTION_ID_PARTS = 9;
+const PARTS_STACK_STATEMACHINE_INDEX = 6;
+const PARTS_EXECUTIONID_PART1_INDEX = 7;
+const PARTS_EXECUTIONID_PART2_INDEX = 8;
 
 export class LogHelper {
   public logger: Logger;
@@ -8,17 +14,62 @@ export class LogHelper {
     this.logger = new Logger({ serviceName: serviceName });
   }
 
-  setSessionItemToLogging(sessionItem: SessionItem) {
+  setSessionItemToLogging(sessionItem: SessionItem | undefined) {
+    if (!sessionItem) {
+      this.logger.warn("SessionItem was not provided to LogHelper");
+      return;
+    }
+
     this.logger.appendKeys({
       govuk_signin_journey_id: sessionItem.clientSessionId,
     });
-    this.logger.info(
-      `Logging attached to government journey id: ${sessionItem.clientSessionId}`
+    this.logger.debug(
+      `Attached govuk_signin_journey_id: ${sessionItem.clientSessionId} for session_id: ${sessionItem.sessionId} to LogHelper`
+    );
+  }
+
+  setStatemachineValuesToLogging(statemachine: Statemachine | undefined) {
+    // Splits apart the string which is epxected to be in the format
+    // arn:aws:states:REGION:ACCOUNT:express:STACK-STATEMACHINE:EXECUTIONID_PART1:EXECUTIONID_PART2
+    if (!statemachine?.executionId) {
+      this.logger.warn(
+        "Statemachine executionId not found - cannnot attach statemachine values to LogHelper"
+      );
+      return;
+    }
+
+    const executionIdParts = statemachine.executionId.split(":");
+    if (executionIdParts.length != EXPECTED_EXECUTION_ID_PARTS) {
+      this.logger.warn(
+        `Statemachine executionId could not be used - expected ${EXPECTED_EXECUTION_ID_PARTS}, found ${executionIdParts.length} parts`
+      );
+
+      return;
+    }
+
+    const sourceStackStateMachine =
+      executionIdParts[PARTS_STACK_STATEMACHINE_INDEX];
+    // "P1:P2"
+    const statemachineExecutionIdUuids = `${executionIdParts[PARTS_EXECUTIONID_PART1_INDEX]}:${executionIdParts[PARTS_EXECUTIONID_PART2_INDEX]}`;
+
+    this.logger.appendKeys({
+      source_stack_statemachine: sourceStackStateMachine,
+    });
+
+    this.logger.appendKeys({
+      statemachine_execution_id_uuids: statemachineExecutionIdUuids,
+    });
+    this.logger.debug(
+      `Attached source_stack_statemachine: ${sourceStackStateMachine} and statemachine_execution_id_uuids ${statemachineExecutionIdUuids} to LogHelper`
     );
   }
 
   info(message: string) {
     this.logger.info(message);
+  }
+
+  warn(message: string) {
+    this.logger.warn(message);
   }
 
   debug(message: string) {

--- a/lib/src/types/otg-token-types.ts
+++ b/lib/src/types/otg-token-types.ts
@@ -1,0 +1,4 @@
+export interface OTGToken {
+  token: string;
+  expiry: number;
+}

--- a/lib/src/util/shared-inputs-validator.ts
+++ b/lib/src/util/shared-inputs-validator.ts
@@ -1,0 +1,56 @@
+export abstract class SharedInputsValidator {
+  public static validateUnmarshalledSessionItem(sessionItem: any) {
+    if (!sessionItem) {
+      throw new Error("Session item was not provided");
+    }
+
+    if (Object.keys(sessionItem).length === 0) {
+      throw new Error("Session item is empty");
+    }
+
+    if (!sessionItem.sessionId) {
+      throw new Error("Session item missing sessionId");
+    }
+
+    if (!sessionItem.expiryDate) {
+      throw new Error("Session item missing expiryDate");
+    }
+
+    if (!sessionItem.clientIpAddress) {
+      throw new Error("Session item missing clientIpAddress");
+    }
+
+    if (!sessionItem.redirectUri) {
+      throw new Error("Session item missing redirectUri");
+    }
+
+    if (!sessionItem.clientSessionId) {
+      throw new Error("Session item missing clientSessionId");
+    }
+
+    if (!sessionItem.createdDate) {
+      throw new Error("Session item missing createdDate");
+    }
+
+    if (!sessionItem.clientId) {
+      throw new Error("Session item missing clientId");
+    }
+
+    // Made optional
+    // if (!sessionItem.persistentSessionId) {
+    //   throw new Error("Session item missing persistentSessionId");
+    // }
+
+    if (!sessionItem.attemptCount && sessionItem.attemptCount != 0) {
+      throw new Error("Session item missing attemptCount");
+    }
+
+    if (!sessionItem.state) {
+      throw new Error("Session item missing state");
+    }
+
+    if (!sessionItem.subject) {
+      throw new Error("Session item missing subject");
+    }
+  }
+}

--- a/lib/tests/util/shared-inputs-validator.test.ts
+++ b/lib/tests/util/shared-inputs-validator.test.ts
@@ -1,0 +1,182 @@
+import { SharedInputsValidator } from "../../src/util/shared-inputs-validator";
+
+describe("SharedInputsValidator", () => {
+  // The following tests test the SharedInputsValidator with a sessionItem that is not correct and confims the assoicated error is thrown
+  it.each([
+    [undefined, "Session item was not provided"],
+    [{}, "Session item is empty"],
+    [
+      {
+        expiryDate: "1234",
+        clientIpAddress: "127.0.0.1",
+        redirectUri: "http://localhost:8085/callback",
+        clientSessionId: "2d35a412-125e-423e-835e-ca66111a38a1",
+        createdDate: "1722954983024",
+        clientId: "unit-test-clientid",
+        subject: "urn:fdc:gov.uk:2022:6dab2b2d-5fcb-43a3-b682-9484db4a2ca5",
+        persistentSessionId: "6c33f1e4-70a9-41f6-a335-7bb036edd3ca",
+        attemptCount: "0",
+        state: "7f42f0cc-1681-4455-872f-dd228103a12e",
+      },
+      "Session item missing sessionId",
+    ],
+    [
+      {
+        clientIpAddress: "127.0.0.1",
+        redirectUri: "http://localhost:8085/callback",
+        clientSessionId: "2d35a412-125e-423e-835e-ca66111a38a1",
+        createdDate: "1722954983024",
+        clientId: "unit-test-clientid",
+        subject: "urn:fdc:gov.uk:2022:6dab2b2d-5fcb-43a3-b682-9484db4a2ca5",
+        persistentSessionId: "6c33f1e4-70a9-41f6-a335-7bb036edd3ca",
+        attemptCount: "0",
+        sessionId: "665ed4d5-7576-4c4b-84ff-99af3a57ea64",
+        state: "7f42f0cc-1681-4455-872f-dd228103a12e",
+      },
+      "Session item missing expiryDate",
+    ],
+    [
+      {
+        expiryDate: "1234",
+        redirectUri: "http://localhost:8085/callback",
+        clientSessionId: "2d35a412-125e-423e-835e-ca66111a38a1",
+        createdDate: "1722954983024",
+        clientId: "unit-test-clientid",
+        subject: "urn:fdc:gov.uk:2022:6dab2b2d-5fcb-43a3-b682-9484db4a2ca5",
+        persistentSessionId: "6c33f1e4-70a9-41f6-a335-7bb036edd3ca",
+        attemptCount: "0",
+        sessionId: "665ed4d5-7576-4c4b-84ff-99af3a57ea64",
+        state: "7f42f0cc-1681-4455-872f-dd228103a12e",
+      },
+      "Session item missing clientIpAddress",
+    ],
+    [
+      {
+        expiryDate: "1234",
+        clientIpAddress: "127.0.0.1",
+        clientSessionId: "2d35a412-125e-423e-835e-ca66111a38a1",
+        createdDate: "1722954983024",
+        clientId: "unit-test-clientid",
+        subject: "urn:fdc:gov.uk:2022:6dab2b2d-5fcb-43a3-b682-9484db4a2ca5",
+        persistentSessionId: "6c33f1e4-70a9-41f6-a335-7bb036edd3ca",
+        attemptCount: "0",
+        sessionId: "665ed4d5-7576-4c4b-84ff-99af3a57ea64",
+        state: "7f42f0cc-1681-4455-872f-dd228103a12e",
+      },
+      "Session item missing redirectUri",
+    ],
+    [
+      {
+        expiryDate: "1234",
+        clientIpAddress: "127.0.0.1",
+        redirectUri: "http://localhost:8085/callback",
+        createdDate: "1722954983024",
+        clientId: "unit-test-clientid",
+        subject: "urn:fdc:gov.uk:2022:6dab2b2d-5fcb-43a3-b682-9484db4a2ca5",
+        persistentSessionId: "6c33f1e4-70a9-41f6-a335-7bb036edd3ca",
+        attemptCount: "0",
+        sessionId: "665ed4d5-7576-4c4b-84ff-99af3a57ea64",
+        state: "7f42f0cc-1681-4455-872f-dd228103a12e",
+      },
+      "Session item missing clientSessionId",
+    ],
+    [
+      {
+        expiryDate: "1234",
+        clientIpAddress: "127.0.0.1",
+        redirectUri: "http://localhost:8085/callback",
+        clientSessionId: "2d35a412-125e-423e-835e-ca66111a38a1",
+        clientId: "unit-test-clientid",
+        subject: "urn:fdc:gov.uk:2022:6dab2b2d-5fcb-43a3-b682-9484db4a2ca5",
+        persistentSessionId: "6c33f1e4-70a9-41f6-a335-7bb036edd3ca",
+        attemptCount: "0",
+        sessionId: "665ed4d5-7576-4c4b-84ff-99af3a57ea64",
+        state: "7f42f0cc-1681-4455-872f-dd228103a12e",
+      },
+      "Session item missing createdDate",
+    ],
+    [
+      {
+        expiryDate: "1234",
+        clientIpAddress: "127.0.0.1",
+        redirectUri: "http://localhost:8085/callback",
+        clientSessionId: "2d35a412-125e-423e-835e-ca66111a38a1",
+        createdDate: "1722954983024",
+        subject: "urn:fdc:gov.uk:2022:6dab2b2d-5fcb-43a3-b682-9484db4a2ca5",
+        persistentSessionId: "6c33f1e4-70a9-41f6-a335-7bb036edd3ca",
+        attemptCount: "0",
+        sessionId: "665ed4d5-7576-4c4b-84ff-99af3a57ea64",
+        state: "7f42f0cc-1681-4455-872f-dd228103a12e",
+      },
+      "Session item missing clientId",
+    ],
+    [
+      {
+        expiryDate: "1234",
+        clientIpAddress: "127.0.0.1",
+        redirectUri: "http://localhost:8085/callback",
+        clientSessionId: "2d35a412-125e-423e-835e-ca66111a38a1",
+        createdDate: "1722954983024",
+        clientId: "unit-test-clientid",
+        persistentSessionId: "6c33f1e4-70a9-41f6-a335-7bb036edd3ca",
+        attemptCount: "0",
+        sessionId: "665ed4d5-7576-4c4b-84ff-99af3a57ea64",
+        state: "7f42f0cc-1681-4455-872f-dd228103a12e",
+      },
+      "Session item missing subject",
+    ],
+    // Made optional
+    // [
+    //   {
+    //     expiryDate: "1234",
+    //     clientIpAddress: "127.0.0.1",
+    //     redirectUri: "http://localhost:8085/callback",
+    //     clientSessionId: "2d35a412-125e-423e-835e-ca66111a38a1",
+    //     createdDate: "1722954983024",
+    //     clientId: "unit-test-clientid",
+    //     subject: "urn:fdc:gov.uk:2022:6dab2b2d-5fcb-43a3-b682-9484db4a2ca5",
+    //     attemptCount: "0",
+    //     sessionId: "665ed4d5-7576-4c4b-84ff-99af3a57ea64",
+    //     state: "7f42f0cc-1681-4455-872f-dd228103a12e",
+    //   },
+    //   "Session item missing persistentSessionId",
+    // ],
+    [
+      {
+        expiryDate: "1234",
+        clientIpAddress: "127.0.0.1",
+        redirectUri: "http://localhost:8085/callback",
+        clientSessionId: "2d35a412-125e-423e-835e-ca66111a38a1",
+        createdDate: "1722954983024",
+        clientId: "unit-test-clientid",
+        subject: "urn:fdc:gov.uk:2022:6dab2b2d-5fcb-43a3-b682-9484db4a2ca5",
+        persistentSessionId: "6c33f1e4-70a9-41f6-a335-7bb036edd3ca",
+        sessionId: "665ed4d5-7576-4c4b-84ff-99af3a57ea64",
+        state: "7f42f0cc-1681-4455-872f-dd228103a12e",
+      },
+      "Session item missing attemptCount",
+    ],
+    [
+      {
+        expiryDate: "1234",
+        clientIpAddress: "127.0.0.1",
+        redirectUri: "http://localhost:8085/callback",
+        clientSessionId: "2d35a412-125e-423e-835e-ca66111a38a1",
+        createdDate: "1722954983024",
+        clientId: "unit-test-clientid",
+        subject: "urn:fdc:gov.uk:2022:6dab2b2d-5fcb-43a3-b682-9484db4a2ca5",
+        persistentSessionId: "6c33f1e4-70a9-41f6-a335-7bb036edd3ca",
+        attemptCount: "0",
+        sessionId: "665ed4d5-7576-4c4b-84ff-99af3a57ea64",
+      },
+      "Session item missing state",
+    ],
+  ])(
+    "should return an error sessionItem is missing required values 'testInputEvent: %s, expectedError: %s'",
+    async (testInputEvent: any, expectedError: string) => {
+      expect(() => {
+        SharedInputsValidator.validateUnmarshalledSessionItem(testInputEvent);
+      }).toThrow(expectedError);
+    }
+  );
+});

--- a/step-functions/fetch-questions.asl.json
+++ b/step-functions/fetch-questions.asl.json
@@ -1,7 +1,15 @@
 {
   "Comment": "Populates the table of questions from the HMRC IVQ API",
-  "StartAt": "Check Session-Id is Present",
+  "StartAt": "Capture Execution Id",
   "States": {
+    "Capture Execution Id": {
+      "Type": "Pass",
+      "Next": "Check Session-Id is Present",
+      "ResultPath": "$.statemachine",
+      "Parameters": {
+        "executionId.$": "$$.Execution.Id"
+      }
+    },
     "Check Session-Id is Present": {
       "Type": "Choice",
       "Choices": [
@@ -111,6 +119,7 @@
       "Parameters": {
         "FunctionName": "${DynamoUnmarshallArn}",
         "Payload": {
+          "statemachine.$": "$.statemachine",
           "marshalledPayload.$": "$.sessionItem.Item"
         }
       },
@@ -183,13 +192,14 @@
       "Parameters": {
         "FunctionName": "${SSMParametersFunctionArn}",
         "Payload": {
+          "sessionItem.$": "$.sessionItem",
+          "statemachine.$": "$.statemachine",
           "requestedParameters": [
             "${OtgApiUrl}",
             "${QuestionsUrl}",
             "${UserAgent}",
             "${Issuer}"
-          ],
-          "sessionItem.$": "$.sessionItem"
+          ]
         }
       },
       "Retry": [
@@ -239,6 +249,8 @@
       "Parameters": {
         "FunctionName": "${DynamoUnmarshallArn}",
         "Payload": {
+          "sessionItem.$": "$.sessionItem",
+          "statemachine.$": "$.statemachine",
           "marshalledPayload.$": "$.personIdentityItem.Item"
         }
       },

--- a/step-functions/get-question.asl.json
+++ b/step-functions/get-question.asl.json
@@ -1,7 +1,15 @@
 {
   "Comment": "Return any unanswered question if available.",
-  "StartAt": "Check Session-Id is Present",
+  "StartAt": "Capture Execution Id",
   "States": {
+    "Capture Execution Id": {
+      "Type": "Pass",
+      "Next": "Check Session-Id is Present",
+      "ResultPath": "$.statemachine",
+      "Parameters": {
+        "executionId.$": "$$.Execution.Id"
+      }
+    },
     "Check Session-Id is Present": {
       "Type": "Choice",
       "Choices": [

--- a/step-functions/issue-credential.asl.json
+++ b/step-functions/issue-credential.asl.json
@@ -1,7 +1,15 @@
 {
   "Comment": "Generates the Verifiable Credential",
-  "StartAt": "Check Bearer Token Present",
+  "StartAt": "Capture Execution Id",
   "States": {
+    "Capture Execution Id": {
+      "Type": "Pass",
+      "Next": "Check Bearer Token Present",
+      "ResultPath": "$.statemachine",
+      "Parameters": {
+        "executionId.$": "$$.Execution.Id"
+      }
+    },
     "Check Bearer Token Present": {
       "Type": "Choice",
       "Choices": [
@@ -23,13 +31,14 @@
       "Parameters": {
         "FunctionName": "${SSMParametersFunctionArn}",
         "Payload": {
+          "sessionItem.$": "$.sessionItem",
+          "statemachine.$": "$.statemachine",
           "requestedParameters": [
             "${MaxJwtTtl}",
             "${JwtTtlUnit}",
             "${Issuer}",
             "${VerifiableCredentialKmsSigningKeyId}"
-          ],
-          "sessionItem.$": "$.sessionItem"
+          ]
         }
       },
       "Retry": [
@@ -204,6 +213,7 @@
       "Parameters": {
         "FunctionName": "${DynamoUnmarshallArn}",
         "Payload": {
+          "statemachine.$": "$.statemachine",
           "marshalledPayload.$": "$.sessionItem.Item"
         }
       },
@@ -269,6 +279,8 @@
       "Parameters": {
         "FunctionName": "${DynamoUnmarshallArn}",
         "Payload": {
+          "sessionItem.$": "$.sessionItem",
+          "statemachine.$": "$.statemachine",
           "marshalledPayload.$": "$.personIdentityItem.Item"
         }
       },
@@ -350,6 +362,8 @@
       "Resource": "arn:aws:states:::lambda:invoke",
       "Parameters": {
         "Payload": {
+          "sessionItem.$": "$.sessionItem",
+          "statemachine.$": "$.statemachine",
           "kid.$": "$.parameters.verifiableCredentialKmsSigningKeyId.value",
           "header.$": "States.JsonToString($.header)",
           "claimsSet.$": "States.JsonToString($.credentialSubject.Payload.vcBody)"

--- a/step-functions/post-answer.asl.json
+++ b/step-functions/post-answer.asl.json
@@ -1,7 +1,15 @@
 {
   "Comment": "State machine for saving answers submitted in the HMRC KBV journey",
-  "StartAt": "Check Session-Id is Present",
+  "StartAt": "Capture Execution Id",
   "States": {
+    "Capture Execution Id": {
+      "Type": "Pass",
+      "Next": "Check Session-Id is Present",
+      "ResultPath": "$.statemachine",
+      "Parameters": {
+        "executionId.$": "$$.Execution.Id"
+      }
+    },
     "Check Session-Id is Present": {
       "Type": "Choice",
       "Choices": [
@@ -100,7 +108,7 @@
               "IsPresent": true
             }
           ],
-          "Next": "Invoke Validating Answers Lambda"
+          "Next": "Unmarshall SessionItem (Step1)"
         }
       ],
       "Default": "Err: SessionItem not valid"
@@ -108,6 +116,38 @@
     "Err: SessionItem not valid": {
       "Type": "Fail",
       "Error": "SessionItem not valid"
+    },
+    "Unmarshall SessionItem (Step1)": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "${DynamoUnmarshallArn}",
+        "Payload": {
+          "statemachine.$": "$.statemachine",
+          "marshalledPayload.$": "$.sessionItem.Item"
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "Unmarshall SessionItem (Step 2)",
+      "ResultPath": "$.sessionItem"
+    },
+    "Unmarshall SessionItem (Step 2)": {
+      "Type": "Pass",
+      "Next": "Invoke Validating Answers Lambda",
+      "ResultPath": "$.sessionItem",
+      "InputPath": "$.sessionItem.Payload"
     },
     "Invoke Validating Answers Lambda": {
       "Type": "Task",
@@ -151,6 +191,7 @@
       "Parameters": {
         "sessionId.$": "$.sessionId",
         "sessionItem.$": "$.sessionItem",
+        "statemachine.$": "$.statemachine",
         "inputAnswer.$": "$.value",
         "answeredQuestionKey.$": "$.key"
       }
@@ -207,7 +248,7 @@
           }
         }
       },
-      "Next": "Get previous answers",
+      "Next": "Get saved answers",
       "ItemsPath": "$.usersQuestions.Items[0].questions.L",
       "MaxConcurrency": 1,
       "ItemSelector": {
@@ -216,7 +257,7 @@
       },
       "ResultPath": "$.answers"
     },
-    "Get previous answers": {
+    "Get saved answers": {
       "Type": "Task",
       "Resource": "arn:aws:states:::dynamodb:getItem",
       "Parameters": {
@@ -227,10 +268,10 @@
           }
         }
       },
-      "Next": "Answers for session exists",
+      "Next": "Saved answers for session exists",
       "ResultPath": "$.dynamoResult"
     },
-    "Answers for session exists": {
+    "Saved answers for session exists": {
       "Type": "Choice",
       "Choices": [
         {
@@ -263,7 +304,7 @@
             "S.$": "$.usersQuestions.Items[0].correlationId.S"
           },
           "expiryDate": {
-            "N.$": "$.sessionItem.Item.expiryDate.N"
+            "N.$": "States.JsonToString($.sessionItem.expiryDate)"
           },
           "answers": {
             "L.$": "$.answers[?(@.M)]"
@@ -391,7 +432,132 @@
           "Next": "Return Question State as Done"
         }
       ],
-      "Default": "Fetch Parameters via SSM Lambda"
+      "Default": "Get final saved answers"
+    },
+    "Get final saved answers": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:getItem",
+      "Parameters": {
+        "TableName": "${AnswersTableName}",
+        "Key": {
+          "sessionId": {
+            "S.$": "$.sessionId"
+          }
+        }
+      },
+      "Next": "Unmarshall savedAnswersItem (Step1)",
+      "ResultPath": "$.savedAnswersItem"
+    },
+    "Unmarshall savedAnswersItem (Step1)": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "${DynamoUnmarshallArn}",
+        "Payload": {
+          "sessionItem.$": "$.sessionItem",
+          "statemachine.$": "$.statemachine",
+          "marshalledPayload.$": "$.savedAnswersItem.Item"
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "Unmarshall savedAnswersItem (Step 2)",
+      "ResultPath": "$.savedAnswersItem"
+    },
+    "Unmarshall savedAnswersItem (Step 2)": {
+      "Type": "Pass",
+      "Next": "DynamoDB Get PersonIdentityItem",
+      "ResultPath": "$.savedAnswersItem",
+      "InputPath": "$.savedAnswersItem.Payload"
+    },
+    "DynamoDB Get PersonIdentityItem": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:getItem",
+      "Parameters": {
+        "TableName": "${PersonIdentityTableName}",
+        "Key": {
+          "sessionId": {
+            "S.$": "$.sessionId"
+          }
+        }
+      },
+      "Next": "Is there a PersonIdentityItem for the sessionId",
+      "TimeoutSeconds": 5,
+      "ResultPath": "$.personIdentityItem"
+    },
+    "Is there a PersonIdentityItem for the sessionId": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.personIdentityItem.Item",
+          "IsPresent": true,
+          "Next": "Unmarshall PersonIdentityItem (Step1)"
+        }
+      ],
+      "Default": "Err: PersonIdentityItem not found"
+    },
+    "Unmarshall PersonIdentityItem (Step1)": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "${DynamoUnmarshallArn}",
+        "Payload": {
+          "sessionItem.$": "$.sessionItem",
+          "statemachine.$": "$.statemachine",
+          "marshalledPayload.$": "$.personIdentityItem.Item"
+        }
+      },
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.SdkClientException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 1,
+          "MaxAttempts": 3,
+          "BackoffRate": 2
+        }
+      ],
+      "Next": "Unmarshall PersonIdentityItem (Step2)",
+      "ResultPath": "$.personIdentityItem"
+    },
+    "Unmarshall PersonIdentityItem (Step2)": {
+      "Type": "Pass",
+      "InputPath": "$.personIdentityItem.Payload",
+      "ResultPath": "$.personIdentityItem",
+      "Next": "Does PersonIdentityItem have a socialSecurityRecord with personalNumber present"
+    },
+    "Does PersonIdentityItem have a socialSecurityRecord with personalNumber present": {
+      "Type": "Choice",
+      "Choices": [
+        {
+          "Variable": "$.personIdentityItem.socialSecurityRecord[0].personalNumber",
+          "IsPresent": true,
+          "Next": "Fetch Parameters via SSM Lambda"
+        }
+      ],
+      "Default": "Err: NINO was not present in shared claims"
+    },
+    "Err: PersonIdentityItem not found": {
+      "Type": "Fail",
+      "Error": "PersonIdentityItem not found"
+    },
+    "Err: NINO was not present in shared claims": {
+      "Type": "Fail",
+      "Error": "NINO was not present in shared claims"
     },
     "Return Question State as Done": {
       "Type": "Pass",
@@ -406,13 +572,14 @@
       "Parameters": {
         "FunctionName": "${SSMParametersFunctionArn}",
         "Payload": {
+          "sessionItem.$": "$.sessionItem",
+          "statemachine.$": "$.statemachine",
           "requestedParameters": [
             "${OtgApiUrl}",
             "${AnswersUrl}",
             "${UserAgent}",
             "${Issuer}"
-          ],
-          "sessionItem.$": "$.sessionItem"
+          ]
         }
       },
       "Retry": [
@@ -497,7 +664,8 @@
         "Payload.$": "$",
         "FunctionName": "${SubmitAnswersArn}"
       },
-      "Next": "Was the answer saved sucessfully"
+      "Next": "Was the answer saved sucessfully",
+      "ResultPath": "$.submitAnswerResult"
     },
     "Was the answer saved sucessfully": {
       "Type": "Choice",
@@ -505,11 +673,11 @@
         {
           "And": [
             {
-              "Variable": "$.Payload.messsage",
+              "Variable": "$.submitAnswerResult.Payload.messsage",
               "IsPresent": true
             },
             {
-              "Variable": "$.Payload.messsage",
+              "Variable": "$.submitAnswerResult.Payload.messsage",
               "StringEquals": "AnswerResults Saved"
             }
           ],


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

	All Statemacines Capture Execution Id step to all state machines - sets values later used by lambdas to log which state machine was the caller (source_stack_statemachine and statemachine_execution_id_uuids)
	Update all lambda call steps to also recieve sessionItem and statemachine
	Add SharedInputsValidator to avoid duplication of common checks in every lambda (sessionItem)
	- SharedInputsValidator persistentSessionId removed from checks (optional)
	All lamdbas delegate sessionItem Validation to SharedInputsValidator
	All lamdas add event input validation
	Add LogHelper to enable capturing govuk_signin_journey_id, source_stack_statemachine and statemachine_execution_id_uuids
	All lambdas/services switch to LogHelper for logging.

	- SharedInputsValidator
	- Add unit tests for validation checks

	- - FetchQuestions Lambda
	- - - FilterQuestionService
	- - - Removing loggging already present in metrics
	- - - Move question key logging to debug level (PII)

	- - Answer Validation Lambda
	- - - Rework Error handling to account for a malformed sessionItem being passed
	- - - Switch to logHelper and validate sessionItem  via SessionItemValidator
	- - - Add Metrics Probe to track Completions

	- Post Answer State Machine
	- - Allow invoking DynamoUnmarshallFunction
	- - Unmarshall the SessionItem in the state machine (for later use by all lambdas)
	- - Get the final saved answers in state machine and store in saveAnswersItem for use in submit answers
	- - Get PersonIdentityItem in the state machine (.personIdentityItem) and Unmarshall it

	- - AnswerValidation Lambda
	- - - Validate Lambda inputs
	- - - Remove use of raw event

	- - SubmitAnswer Lambda
	- - Validate Lambda inputs
	- - Rework unit test to account for changes
	- - SubmitAnswerService
	- - Use Types in method inputs and not raw event
	- - Remove internal dynamo fetch for PersonIdentity and use the one provided by the state machine.
	- Append SubmitAnswers result in $.submitAnswerResult to allow state machine event to pass through

	- - Create Authcode Lambda
	- - - Validate lambda inputs
	- - - Remove use of raw event
	- - - Add metrics capture

	- IssueCredential State Machine
	- - IssueCredential Lambda
	- - - Switch to SharedInputsValidator
	- - JWT Signer Lambda
	- - Align with input validation approach
	- - Correct unit test that always pass

### Why did it change

To enable tracking errors/issues with individual user journeys

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1285](https://govukverify.atlassian.net/browse/LIME-1285)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc. -->


[LIME-1285]: https://govukverify.atlassian.net/browse/LIME-1285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ