### PR TITLE
LIME-1285 Fix incorrect token value used for answers api request

### DIFF
--- a/lambdas/submit-answer/src/submit-answer-handler.ts
+++ b/lambdas/submit-answer/src/submit-answer-handler.ts
@@ -195,8 +195,8 @@ export class SubmitAnswerHandler implements LambdaInterface {
     }
 
     // OTG Token
-    const otgToken: OTGToken = event?.bearerToken; // NOTE expiry is not checked as its not used currently
-    if (!event.parameters) {
+    const otgToken = event?.bearerToken; // NOTE expiry is not checked as its not used currently
+    if (!otgToken) {
       throw new Error("No otgToken provided");
     }
 
@@ -209,7 +209,10 @@ export class SubmitAnswerHandler implements LambdaInterface {
       nino: nino,
       savedAnswersItem: savedAnswersItem as SavedAnswersItem,
       parameters: parameters,
-      otgToken: otgToken,
+      otgToken: {
+        token: otgToken.value,
+        expiry: otgToken.expiry,
+      } as OTGToken,
     } as SubmitAnswerInputs;
   }
 }

--- a/lambdas/submit-answer/tests/submit-answer-handler.test.ts
+++ b/lambdas/submit-answer/tests/submit-answer-handler.test.ts
@@ -120,7 +120,7 @@ describe("submit-answer-handler", () => {
     },
     bearerToken: {
       expiry: Date.now() + 7200 * 1000,
-      token: "TEST_TOKEN_VALUE",
+      value: "TEST_TOKEN_VALUE",
     },
   };
 


### PR DESCRIPTION
## Proposed changes

### What changed

Fix incorrect token value used for answers api request

### Why did it change

Answers API request failed due to the incorrect value

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1285](https://govukverify.atlassian.net/browse/LIME-1285)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc. -->


[LIME-1285]: https://govukverify.atlassian.net/browse/LIME-1285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ