### PR TITLE
LIME-1169 Set log group retention in days to 30 for all log groups

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -151,56 +151,56 @@
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 102
+        "line_number": 106
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 110
+        "line_number": 114
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 118
+        "line_number": 122
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 126
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 134
+        "line_number": 138
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "a6f001558be9f15f42a6ddea2a1b8f7b6b914d2a",
         "is_verified": false,
-        "line_number": 143
+        "line_number": 147
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 154
+        "line_number": 158
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 178
+        "line_number": 182
       }
     ],
     "lambdas/dynamo-unmarshall/tests/dynamo-unmarshall-handler.test.ts": [
@@ -250,5 +250,5 @@
       }
     ]
   },
-  "generated_at": "2024-09-30T13:08:31Z"
+  "generated_at": "2024-10-04T12:19:38Z"
 }

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -53,6 +53,10 @@ Parameters:
     Description: "The stack containing the TXMA infrastructure"
     Type: String
     Default: txma-infrastructure
+  LogGroupRetentionInDays:
+    Description: "Retention for all log groups"
+    Type: Number
+    Default: "30"
 
 Conditions:
   # Avoid adding a standalone IsDevEnv condition
@@ -245,7 +249,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/apigateway/${AWS::StackName}-public-AccessLogs
-      RetentionInDays: 30
+      RetentionInDays: !Ref LogGroupRetentionInDays
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   PublicKbvHmrcApiAccessLogGroupSubscriptionFilter:
@@ -324,7 +328,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/apigateway/${AWS::StackName}-private-AccessLogs
-      RetentionInDays: 30
+      RetentionInDays: !Ref LogGroupRetentionInDays
       KmsKeyId: !GetAtt LoggingKmsKey.Arn
 
   PrivateKbvHmrcApiAccessLogGroupSubscriptionFilter:
@@ -440,7 +444,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-FetchQuestionsStateMachine-logs
-      RetentionInDays: 30
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   FetchQuestionsStateMachineLogGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter
@@ -501,7 +505,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-GetQuestion-state-machine-logs
-      RetentionInDays: 30
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   GetQuestionStateMachineLogGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter
@@ -603,7 +607,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-PostAnswer-state-machine-logs
-      RetentionInDays: 30
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   PostAnswerStateMachineLogGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter
@@ -688,7 +692,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/vendedlogs/states/${AWS::StackName}-IssueCredential-state-machine-logs
-      RetentionInDays: 30
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   IssueCredentialStateMachineLogGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter
@@ -734,7 +738,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/lambda/${OTGTokenFunction}"
-      RetentionInDays: 30
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   OTGTokenFunctionLogGroupLogGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter
@@ -801,7 +805,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/lambda/${FetchQuestionsFunction}"
-      RetentionInDays: 30
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   FetchQuestionsFunctionLogGroupLogGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter
@@ -876,7 +880,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/lambda/${SubmitAnswerFunction}"
-      RetentionInDays: 30
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   SubmitAnswerFunctionLogGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter
@@ -907,7 +911,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/lambda/${AWS::StackName}-${CreateAuthCodeFunction}"
-      RetentionInDays: 30
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   CreateAuthCodeFunctionLogGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter
@@ -938,7 +942,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/lambda/${AWS::StackName}-${EvidenceCheckDetailsFunction}"
-      RetentionInDays: 30
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   EvidenceCheckDetailsFunctionLogGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter
@@ -1007,7 +1011,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/lambda/${IssueCredentialFunction}"
-      RetentionInDays: 30
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   IssueCredentialFunctionLogGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter
@@ -1046,7 +1050,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub /aws/lambda/${AWS::StackName}/JwtSignerFunction
-      RetentionInDays: 30
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   JwtSignerFunctionLogGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter
@@ -1078,7 +1082,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/lambda/${AnswerValidationFunction}"
-      RetentionInDays: 30
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   AnswerValidationFunctionLogGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter
@@ -1124,7 +1128,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/lambda/${DynamoUnmarshallFunction}"
-      RetentionInDays: 30
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   DynamoUnmarshallFunctionLogGroupLogGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter
@@ -1179,7 +1183,7 @@ Resources:
     Type: AWS::Logs::LogGroup
     Properties:
       LogGroupName: !Sub "/aws/lambda/${SSMParametersFunction}"
-      RetentionInDays: 30
+      RetentionInDays: !Ref LogGroupRetentionInDays
 
   SSMParametersFunctionLogGroupSubscriptionFilterCsls:
     Type: AWS::Logs::SubscriptionFilter


### PR DESCRIPTION
## Proposed changes

### What changed

Ensure log groups are all set to 30 days retention

### Why did it change

To ensure log groups do not have extended retention lengths

### Issue tracking
<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1169](https://govukverify.atlassian.net/browse/LIME-1169)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc-->


[LIME-1169]: https://govukverify.atlassian.net/browse/LIME-1169?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ