### PR TITLE
LIME-1262 - Updating Nbf field in VC to be in seconds

### DIFF
--- a/lambdas/issue-credential/src/issue-credential-handler.ts
+++ b/lambdas/issue-credential/src/issue-credential-handler.ts
@@ -90,7 +90,7 @@ export class IssueCredentialHandler implements LambdaInterface {
       const correlationId = answerResults.Item.correlationId;
 
       const sub = input.sessionItem.subject;
-      const nbf = Date.now();
+      const nbf = Date.now() / 1000;
       const iss = input.issuer;
       const jti = "urn:uuid:" + uuidv4().toString();
 


### PR DESCRIPTION
### What changed
Updated nbf field to be in seconds instead of miliseconds