### PR TITLE
LIME-1466 updates Lambda config for decom

### DIFF
--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -56,7 +56,7 @@ Parameters:
   LogGroupRetentionInDays:
     Description: "Retention for all log groups"
     Type: Number
-    Default: "30"
+    Default: "7"
 
 Conditions:
   # Avoid adding a standalone IsDevEnv condition
@@ -207,8 +207,8 @@ Resources:
           # Disable data trace in production to avoid logging customer sensitive information
           DataTraceEnabled: !If [IsProdEnvironment, false, true]
           MetricsEnabled: true
-          ThrottlingRateLimit: 200
-          ThrottlingBurstLimit: 400
+          ThrottlingRateLimit: 50
+          ThrottlingBurstLimit: 100
       AccessLogSetting:
         DestinationArn: !GetAtt PublicKbvHmrcApiAccessLogGroup.Arn
         Format: >-
@@ -273,8 +273,8 @@ Resources:
           # Disable data trace in production to avoid logging customer sensitive information
           DataTraceEnabled: !If [IsProdEnvironment, false, true]
           MetricsEnabled: true
-          ThrottlingRateLimit: 200
-          ThrottlingBurstLimit: 400
+          ThrottlingRateLimit: 50
+          ThrottlingBurstLimit: 100
       AccessLogSetting:
         DestinationArn: !GetAtt PrivateKbvHmrcApiAccessLogGroup.Arn
         Format: >-
@@ -1266,11 +1266,11 @@ Resources:
         - ApiId: !Ref PublicKbvHmrcApi
           Stage: !Ref Environment
       Quota:
-        Limit: 500000
+        Limit: 100000
         Period: DAY
       Throttle:
-        RateLimit: 200 # allowed requests per second
-        BurstLimit: 400 # requests the API can handle concurrently
+        RateLimit: 50 # allowed requests per second
+        BurstLimit: 100 # requests the API can handle concurrently
 
   PrivateKbvHmrcApiUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
@@ -1282,11 +1282,11 @@ Resources:
         - ApiId: !Ref PrivateKbvHmrcApi
           Stage: !Ref Environment
       Quota:
-        Limit: 500000
+        Limit: 100000
         Period: DAY
       Throttle:
-        RateLimit: 200 # allowed requests per second
-        BurstLimit: 400 # requests the API can handle concurrently
+        RateLimit: 50 # allowed requests per second
+        BurstLimit: 100 # requests the API can handle concurrently
 
   LinkUsagePlanApiKey1:
     Condition: IsDeployedFromPipeline


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

API request throttle limits and lambda logging retention days reduced. 

### Why did it change

To reduce maintenance costs for decommissioning of HMRC KBV CRI.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1466](https://govukverify.atlassian.net/browse/LIME-1466)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc. -->

### Evidence
- Successful user journey completed locally 


[LIME-1466]: https://govukverify.atlassian.net/browse/LIME-1466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ