### PR TITLE
LIME-1517: Disable Tests on BE Repo (UI + API) for HMRC KBV Closing Down

### DIFF
--- a/feature-tests/tests/resources/features/createSession/createSessionRequest-sessionId-HappyPath.feature
+++ b/feature-tests/tests/resources/features/createSession/createSessionRequest-sessionId-HappyPath.feature
@@ -1,6 +1,6 @@
 Feature: CORE-STUB-CreateSessionRequest-HappyPath.feature
 
-    @pre-merge @hmrc-corestub
+    # @pre-merge @hmrc-corestub
     Scenario Outline: Happy Path - Request for user claimSet from CoreStub for Valid User with Nino <selectedNino>
         Given I send a new core stub request to the core stub with nino value <selectedNino> for user <userId>
         Examples:

--- a/feature-tests/tests/resources/features/hmrcGet/hmrcQuestion-HappyPath.feature
+++ b/feature-tests/tests/resources/features/hmrcGet/hmrcQuestion-HappyPath.feature
@@ -1,6 +1,6 @@
 Feature: HMRC-KBV-GET-Question-HappyPath.feature
 
-    @pre-merge @hmrc-question
+    # @pre-merge @hmrc-question
     Scenario Outline: Happy Path - Get request to /question Endpoint for userId with Nino <selectedNino>
         Given I send a new questions request to the core stub with nino value <selectedNino> for user <userId>
         When I send a questions POST request with <contentType> and <accept> to the fetchQuestions endpoint

--- a/feature-tests/tests/resources/features/hmrcGet/hmrcQuestion-UnhappyPath.feature
+++ b/feature-tests/tests/resources/features/hmrcGet/hmrcQuestion-UnhappyPath.feature
@@ -1,6 +1,6 @@
 Feature: HMRC-KBV-GET-Question-UnhappyPath.feature
 
-    @pre-merge @hmrc-question
+    # @pre-merge @hmrc-question
     Scenario Outline: Unhappy Path - Get request to /question Endpoint - Invalid header Values - sessionId
         Given I send a new questions request to the core stub with a nino value <selectedNino> for user <userId>
         When I send a new questions POST request with <contentType> and <accept> to the fetchQuestions endpoint
@@ -10,7 +10,7 @@ Feature: HMRC-KBV-GET-Question-UnhappyPath.feature
             | contentType      | accept           | statusCode | selectedNino | session_id                           | userId |
             | application/json | application/json | 403        | KE000000C    | 44443939-4cf4-41e9-9fee-231e16e9f382 | 197    |
 
-    @pre-merge @hmrc-Question
+    # @pre-merge @hmrc-Question
     Scenario Outline: Unhappy Path - Get request to /question Endpoint - Invalid Header Values - contentType and accept
         Given I send a valid questions request to the core stub with nino value <selectedNino> for user <userId>
         And I send a POST request to the fetchQuestions endpoint
@@ -20,7 +20,7 @@ Feature: HMRC-KBV-GET-Question-UnhappyPath.feature
             | contentType | accept           | statusCode | selectedNino | userId |
             | text/html   | application/json | 415        | KE000000C    | 197    |
 
-    @pre-merge @hmrc-question
+    # @pre-merge @hmrc-question
     Scenario Outline: Unhappy Path - Get request to /question Endpoint - Invalid Endpoint
         Given I send a valid questions request to the core stub with selected nino value <selectedNino> for user <userId>
         When I send a GET request to a Invalid question endpoint with a valid <contentType> and <accept>

--- a/feature-tests/tests/resources/features/hmrcPost/hmrcAnswer-HappyPath.feature
+++ b/feature-tests/tests/resources/features/hmrcPost/hmrcAnswer-HappyPath.feature
@@ -13,16 +13,16 @@ Feature: HMRC-KBV-POST-Answer-HappyPath.feature
         Examples:
             | contentType      | accept           | statusCode | intermediateStatusCode | finalStatusCode | selectedNino | verificationScore     | userId |
             | application/json | application/json | 200        | 202                    | 204             | KE000000C    | "verificationScore":2 | 197    |
-            | application/json | application/json | 200        | 202                    | 204             | AA000000A    | "verificationScore":2 | 197    |
-            | application/json | application/json | 200        | 202                    | 204             | AA000003A    | "verificationScore":2 | 197    |
-            | application/json | application/json | 200        | 202                    | 204             | AA000004A    | "verificationScore":2 | 197    |
-            | application/json | application/json | 200        | 202                    | 204             | AA000005A    | "verificationScore":2 | 197    |
-            | application/json | application/json | 200        | 202                    | 204             | AA000006A    | "verificationScore":2 | 197    |
-            | application/json | application/json | 200        | 202                    | 204             | AA000003I    | "verificationScore":2 | 197    |
-            | application/json | application/json | 200        | 202                    | 204             | AA000003C    | "verificationScore":0 | 197    |
-            | application/json | application/json | 200        | 202                    | 204             | AA000003Z    | "verificationScore":0 | 197    |
+            # | application/json | application/json | 200        | 202                    | 204             | AA000000A    | "verificationScore":2 | 197    |
+            # | application/json | application/json | 200        | 202                    | 204             | AA000003A    | "verificationScore":2 | 197    |
+            # | application/json | application/json | 200        | 202                    | 204             | AA000004A    | "verificationScore":2 | 197    |
+            # | application/json | application/json | 200        | 202                    | 204             | AA000005A    | "verificationScore":2 | 197    |
+            # | application/json | application/json | 200        | 202                    | 204             | AA000006A    | "verificationScore":2 | 197    |
+            # | application/json | application/json | 200        | 202                    | 204             | AA000003I    | "verificationScore":2 | 197    |
+            # | application/json | application/json | 200        | 202                    | 204             | AA000003C    | "verificationScore":0 | 197    |
+            # | application/json | application/json | 200        | 202                    | 204             | AA000003Z    | "verificationScore":0 | 197    |
 
-    @pre-merge @hmrc-answer
+    # @pre-merge @hmrc-answer
     Scenario Outline: Happy Path - Post request to /answer Endpoint for nino <selectedNino> with 2 questions over 2 questionKeys
         Given I send a new request to the core stub with nino value <selectedNino> for a user <userId> with 2 questions
         Given I send a valid 2 question POST request with <contentType> and <accept> to the fetchQuestions endpoint with status code <statusCode>
@@ -36,7 +36,7 @@ Feature: HMRC-KBV-POST-Answer-HappyPath.feature
             | application/json | application/json | 200        | 204             | AA000002Z    | "verificationScore":0 | 197    |
             | application/json | application/json | 200        | 204             | AA000002C    | "verificationScore":0 | 197    |
 
-    @pre-merge @hmrc-answer
+    # @pre-merge @hmrc-answer
     Scenario Outline: Happy Path - Post request to /answer Endpoint for nino <selectedNino> with 3 questions including 1 low confidence question
         Given I send a new request to the core stub with nino value <selectedNino> for a user <userId> with 3 questions including 1 low confidence question
         Given I send a POST request with <contentType> and <accept> to the fetchQuestions endpoint with status code <statusCode>

--- a/feature-tests/tests/resources/features/hmrcPost/hmrcAnswer-UnhappyPath.feature
+++ b/feature-tests/tests/resources/features/hmrcPost/hmrcAnswer-UnhappyPath.feature
@@ -1,6 +1,6 @@
 Feature: HMRC-KBV-POST-Answer-UnhappyPath.feature
 
-    @pre-merge @hmrc-answer
+    # @pre-merge @hmrc-answer
     Scenario Outline: Unhappy Path - Post request to /answer Endpoint - Invalid Header Values - sessionId
         Given I send a request to the core stub with nino value <selectedNino> for user <userId>
         Given I send a valid POST request with <contentType> and <accept> to the fetchQuestions endpoint
@@ -11,7 +11,7 @@ Feature: HMRC-KBV-POST-Answer-UnhappyPath.feature
             | contentType      | accept           | statusCode | selectedNino | session_id                           | userId |
             | application/json | application/json | 403        | AA000002A    | 44443939-4cf4-41e9-9fee-231e16e9f382 | 197    |
 
-    @failing-regression @hmrc-answer
+    # @failing-regression @hmrc-answer
     # Confirm with Dev the expected outcome for invalid contentType headers
     Scenario Outline: Unhappy Path - Post request to /answer Endpoint - Invalid Header Values - contentType and accept
         Given I send a valid request to the core stub with nino value <selectedNino> for user <userId>
@@ -23,7 +23,7 @@ Feature: HMRC-KBV-POST-Answer-UnhappyPath.feature
             | contentType | accept           | statusCode | selectedNino | responseMessage        | userId |
             | text/html   | application/json | 415        | KE000000C    | Unsupported Media Type | 197    |
 
-    @pre-merge @hmrc-answer
+    # @pre-merge @hmrc-answer
     Scenario Outline: Unhappy Path - Post request to /answer Endpoint - Invalid Endpoint
         Given I send a valid request to the core stub with the selected nino value <selectedNino> for user <userId>
         And I send a valid new POST request to the fetchQuestions endpoint
@@ -34,7 +34,7 @@ Feature: HMRC-KBV-POST-Answer-UnhappyPath.feature
             | contentType | accept           | statusCode | selectedNino | responseMessage              | userId |
             | text/html   | application/json | 403        | AA000002A    | Missing Authentication Token | 197    |
 
-    @pre-merge @hmrc-answer
+    # @pre-merge @hmrc-answer
     Scenario Outline: Unhappy Path - Post request to /answer Endpoint - Invalid Answer Body - Invalid Question Key
         Given I send a request to the core stub with a nino value <selectedNino> for user <userId>
         Given I send a new valid POST request to the fetchQuestions endpoint
@@ -45,7 +45,7 @@ Feature: HMRC-KBV-POST-Answer-UnhappyPath.feature
             | statusCode | selectedNino | userId |
             | 500        | AA000002A    | 197    |
 
-    @pre-merge @hmrc-answer
+    # @pre-merge @hmrc-answer
     Scenario Outline: Unhappy Path - Post request to /answer Endpoint - Invalid Answer Body - Incorrect Question Key
         Given I send a new request to the core stub with a nino value <selectedNino> for user <userId>
         Given I send a new POST request to the fetchQuestions endpoint
@@ -56,7 +56,7 @@ Feature: HMRC-KBV-POST-Answer-UnhappyPath.feature
             | statusCode | selectedNino | userId |
             | 204        | AA000002A    | 197    |
 
-    @pre-merge @hmrc-answer
+    # @pre-merge @hmrc-answer
     Scenario Outline: Unhappy Path - Post request to /answer Endpoint - Invalid Answer Body - Incorrect Question Key Value
         Given I send a new valid request to the core stub with a nino value <selectedNino> for user <userId>
         Given I send a new POST request to the fetchQuestions endpoint for a valid userId
@@ -77,7 +77,7 @@ Feature: HMRC-KBV-POST-Answer-UnhappyPath.feature
             | 400        | AL000000S    | {"": "","": ""}                                                                                     | 197    |
             | 400        | AL000000S    | {"questionKeys": "tc-amount","value": "400"}                                                        | 197    |
 
-    @pre-merge @hmrc-answer
+    # @pre-merge @hmrc-answer
     Scenario Outline: Unhappy Path - Post request to /answer Endpoint - Invalid Header Values - Malformed Response
         Given I send a answer request to the core stub with nino value <selectedNino> for user <userId>
         Given I send a new valid POST request with <contentType> and <accept> to the fetchQuestions endpoint with status code <statusCode>

--- a/feature-tests/tests/resources/features/hmrcPost/hmrcFetchQuestions-HappyPath.feature
+++ b/feature-tests/tests/resources/features/hmrcPost/hmrcFetchQuestions-HappyPath.feature
@@ -1,6 +1,6 @@
 Feature: HMRC-KBV-GET-FetchQuestions-HappyPath.feature
 
-    @pre-merge @hmrc-fetchquestions
+    # @pre-merge @hmrc-fetchquestions
     Scenario Outline: Happy Path - Post Request to /fetchquestions Endpoint for userId with Nino <selectedNino>
         Given I send a new fetchquestions request to the core stub with nino value <selectedNino> for user <userId>
         When I send a POST request with <contentType> and <accept> to the fetchQuestions endpoint
@@ -9,7 +9,7 @@ Feature: HMRC-KBV-GET-FetchQuestions-HappyPath.feature
             | contentType      | accept           | statusCode | selectedNino | userId |
             | application/json | application/json | 200        | KE000000C    | 197    |
 
-    @pre-merge @hmrc-fetchquestions
+    # @pre-merge @hmrc-fetchquestions
     Scenario Outline: Happy Path - Post Request to /fetchquestions Endpoint for same userId with Nino <selectedNino
         Given I send a fetchquestions request to the core stub with nino value <selectedNino> for user <userId>
         When I send a POST request with <contentType> and <accept> to the fetchQuestions endpoint and receive a statusCode <statusCode>
@@ -19,7 +19,7 @@ Feature: HMRC-KBV-GET-FetchQuestions-HappyPath.feature
             | contentType      | accept           | statusCode | selectedNino | finalStatusCode | userId |
             | application/json | application/json | 200        | KE000000C    | 204             | 197    |
 
-    @pre-merge @hmrc-fetchquestions
+    # @pre-merge @hmrc-fetchquestions
     Scenario Outline: Happy Path - Post Request to /fetchquestions Endpoint for userId with Nino <selectedNino> with only low confidence questionKey
         Given I send a new fetchquestions request to the core stub with nino value <selectedNino> for user <userId>
         When I send a POST request with <contentType> and <accept> to the fetchQuestions endpoint

--- a/feature-tests/tests/resources/features/hmrcPost/hmrcFetchQuestions-UnhappyPath.feature
+++ b/feature-tests/tests/resources/features/hmrcPost/hmrcFetchQuestions-UnhappyPath.feature
@@ -1,6 +1,6 @@
 Feature: HMRC-KBV-GET-FetchQuestions-UnhappyPath.feature
 
-    @pre-merge @hmrc-fetchquestions
+    # @pre-merge @hmrc-fetchquestions
     Scenario Outline: Unhappy Path - Post Request to /fetchquestions Endpoint - Invalid Header Values - sessionId
         Given I send a valid fetchquestions request to the core stub with nino value <selectedNino> for user <userId>
         When I send a POST request with <contentType> and <accept> to the fetchQuestions endpoint with a invalid sessionId <session_id>
@@ -9,7 +9,7 @@ Feature: HMRC-KBV-GET-FetchQuestions-UnhappyPath.feature
             | contentType      | accept           | statusCode | selectedNino | session_id                           | userId |
             | application/json | application/json | 403        | KE000000C    | 44443939-4cf4-41e9-9fee-231e16e9f382 | 197    |
 
-    @failing-regression @hmrc-fetchquestions
+    # @failing-regression @hmrc-fetchquestions
     # Confirm with Dev the expected outcome for invalid contentType headers
     Scenario Outline: Unhappy Path - Post Request to /fetchquestions Endpoint - Invalid Header Values - contentType and accept
         Given I send a new valid fetchquestions request to the core stub with nino value <selectedNino> for user <userId>
@@ -20,7 +20,7 @@ Feature: HMRC-KBV-GET-FetchQuestions-UnhappyPath.feature
             | text/html        | application/json | 400        | KE000000C    | 197    |
             | application/json | text/html        | 403        | KE000000C    | 197    |
 
-    @failing-regression @hmrc-fetchquestions
+    # @failing-regression @hmrc-fetchquestions
     Scenario Outline: Unhappy Path - Post Request to /fetchquestions Endpoint - Invalid Endpoint
         Given I send a new valid fetchquestions request to the core stub with the selected nino value <selectedNino> for user <userId>
         When I send a POST request with valid headers <contentType> and <accept> to a Invalid fetchQuestions endpoint
@@ -29,7 +29,7 @@ Feature: HMRC-KBV-GET-FetchQuestions-UnhappyPath.feature
             | contentType      | accept           | statusCode | selectedNino | userId |
             | application/json | application/json | 403        | KE000000C    | 197    |
 
-    @pre-merge @hmrc-fetchquestions
+    # @pre-merge @hmrc-fetchquestions
     Scenario Outline: Unhappy Path - Post Request to /fetchquestions Endpoint - Invalid Nino <selectedNino>
         Given I send a new fetchquestions request to the core stub with Invalid nino value <selectedNino> for user <userId>
         When I send a POST request with <contentType> and <accept> to the fetchQuestions endpoint with the invalid Nino
@@ -39,7 +39,7 @@ Feature: HMRC-KBV-GET-FetchQuestions-UnhappyPath.feature
             | application/json | application/json | 400        | XX000000A    | 197    |
             | application/json | application/json | 400        | KE000 000C   | 197    |
 
-    @pre-merge @hmrc-fetchquestions
+    # @pre-merge @hmrc-fetchquestions
     Scenario Outline: Unhappy Path - Post Request to /fetchquestions Endpoint - Single Category Nino <selectedNino>
         Given I send a new fetchquestions request to the core stub with a nino value <selectedNino> for user <userId>
         When I send a POST request with <contentType> and <accept> to the fetchQuestions endpoint with the selected Nino
@@ -48,7 +48,7 @@ Feature: HMRC-KBV-GET-FetchQuestions-UnhappyPath.feature
             | contentType      | accept           | statusCode | selectedNino | userId |
             | application/json | application/json | 400        | CC000001C    | 197    |
 
-    @pre-merge @hmrc-fetchquestions
+    # @pre-merge @hmrc-fetchquestions
     Scenario Outline: Unhappy Path - Post Request to /fetchquestions Endpoint - No Questions Nino <selectedNino>
         Given I send a new fetchquestions request to the core stub with a no questions nino value <selectedNino> for user <userId>
         When I send a POST request with <contentType> and <accept> to fetchQuestions endpoint with the selected Nino
@@ -57,7 +57,7 @@ Feature: HMRC-KBV-GET-FetchQuestions-UnhappyPath.feature
             | contentType      | accept           | statusCode | selectedNino | userId |
             | application/json | application/json | 400        | QQ000000Q    | 197    |
 
-    @pre-merge @hmrc-fetchquestions
+    # @pre-merge @hmrc-fetchquestions
     Scenario Outline: Unhappy Path - Post Request to /fetchquestions Endpoint - Low Confidence Question Nino <selectedNino>
         Given I send a new fetchquestions request to the core stub with a low confidence nino value <selectedNino> for user <userId>
         When I send a POST request with <contentType> and <accept> to fetchQuestions endpoint with a Nino containing a low confidence question

--- a/feature-tests/tests/resources/features/ui/hmrcGet/hmrcQuestion-HappyPath.feature
+++ b/feature-tests/tests/resources/features/ui/hmrcGet/hmrcQuestion-HappyPath.feature
@@ -1,6 +1,6 @@
 Feature: HMRC-KBV-GET-Question-HappyPath.feature
 
-    @post-merge
+    # @post-merge
     Scenario Outline: Happy Path - Get request to /question Endpoint for userId
         Given I start the journey with the backend stub and nino <selectedNino> for user <userId>
         When I select continue on the context page triggering fetch questions Request

--- a/feature-tests/tests/resources/features/ui/hmrcPost/hmrcAnswer-HappyPath.feature
+++ b/feature-tests/tests/resources/features/ui/hmrcPost/hmrcAnswer-HappyPath.feature
@@ -1,6 +1,6 @@
 Feature: HMRC-KBV-POST-Answer-HappyPath.feature
 
-    @post-merge @test
+    # @post-merge
     Scenario Outline: Happy Path - Post request to /answer Endpoint for userId with >=3 questions over 2 questionKeys
         Given I start the journey with the backend stub and nino <selectedNino> for user <userId>
         When I select continue on the context page triggering fetch questions Request
@@ -11,15 +11,15 @@ Feature: HMRC-KBV-POST-Answer-HappyPath.feature
         Examples:
             | selectedNino | verificationScore       | userId |
             | KE000000C    | "verificationScore": 2, | 197    |
-            | AA000000A    | "verificationScore": 2, | 197    |
-            | AA000003A    | "verificationScore": 2, | 197    |
-            | AA000004A    | "verificationScore": 2, | 197    |
-            | AA000005A    | "verificationScore": 2, | 197    |
-            | AA000006A    | "verificationScore": 2, | 197    |
-            | AA000003C    | "verificationScore": 0, | 197    |
-            | AA000003Z    | "verificationScore": 0, | 197    |
+            # | AA000000A    | "verificationScore": 2, | 197    |
+            # | AA000003A    | "verificationScore": 2, | 197    |
+            # | AA000004A    | "verificationScore": 2, | 197    |
+            # | AA000005A    | "verificationScore": 2, | 197    |
+            # | AA000006A    | "verificationScore": 2, | 197    |
+            # | AA000003C    | "verificationScore": 0, | 197    |
+            # | AA000003Z    | "verificationScore": 0, | 197    |
 
-    @post-merge
+    # @post-merge
     Scenario Outline: Happy Path - Post request to /answer Endpoint for userId with 2 questions over 2 questionKeys
         Given I start the journey with the backend stub and nino <selectedNino> for user <userId>
         When I select continue on the context page triggering fetch questions Request
@@ -33,7 +33,7 @@ Feature: HMRC-KBV-POST-Answer-HappyPath.feature
             | AA000002Z    | "verificationScore": 0, | 197    |
             | AA000002C    | "verificationScore": 0, | 197    |
 
-    @uat
+    # @uat
     Scenario Outline: Happy Path - Post request to /answer Endpoint for HMRC userId with >=3 questions over 2 questionKeys with verificationScore of 2
         Given I start the journey with the backend stub for nino <selectedNino> for user <userId> with FirstName <firstName> and FamilyName <familyName>
         When I select continue on the context page calling fetch questions Request
@@ -44,4 +44,4 @@ Feature: HMRC-KBV-POST-Answer-HappyPath.feature
         Examples:
             | selectedNino | verificationScore       | userId | firstName | familyName  |
             | AA000003D    | "verificationScore": 2, | 197    | KENNETH   | DECERQUEIRA |
-            | AB000001A    | "verificationScore": 2, | 197    | HARRY     | LIGHT       |
+            # | AB000001A    | "verificationScore": 2, | 197    | HARRY     | LIGHT       |

--- a/feature-tests/tests/resources/page/stub-page.ts
+++ b/feature-tests/tests/resources/page/stub-page.ts
@@ -12,7 +12,7 @@ export class StubPage extends AbstractPageObject {
     await this.driver
       .findElement(By.xpath('//*[@id="main-content"]/div/details/summary'))
       .click();
-    let vcText = await this.driver.findElement(this.vcBlock).getText();
+    const vcText = await this.driver.findElement(this.vcBlock).getText();
     return vcText;
   };
 }

--- a/feature-tests/tests/resources/step-definitions/ui/context-page.step.ts
+++ b/feature-tests/tests/resources/step-definitions/ui/context-page.step.ts
@@ -15,7 +15,7 @@ const feature = loadFeature(
 defineFeature(feature, (test) => {
   let driver: WebDriver;
 
-  let chromeOptions = new Options();
+  const chromeOptions = new Options();
   if (process.env.CI) {
     chromeOptions.addArguments("--no-sandbox");
     chromeOptions.addArguments("--whitelisted-ips= ");
@@ -50,8 +50,8 @@ defineFeature(feature, (test) => {
       /^I start the journey with the backend stub and nino (.*) for user (.*)$/,
       async (selectedNino, userId) => {
         await generateClaimsUrl(selectedNino, userId);
-        let encodedClaims = await postUpdatedClaimsUrl(false);
-        let contextPage: ContextPage = new ContextPage(driver);
+        const encodedClaims = await postUpdatedClaimsUrl(false);
+        const contextPage: ContextPage = new ContextPage(driver);
         await contextPage.goTo(
           EndPoints.FRONTEND +
             "/oauth2/authorize?request=" +
@@ -65,14 +65,14 @@ defineFeature(feature, (test) => {
     when(
       /^I select continue on the context page triggering fetch questions Request$/,
       async () => {
-        let contextPage: ContextPage = new ContextPage(driver);
+        const contextPage: ContextPage = new ContextPage(driver);
         await contextPage.clickContinue();
       }
     );
 
     then(/^I see a question page$/, async () => {
-      let pageTitle = await driver.getTitle();
-      let isQuestionPage =
+      const pageTitle = await driver.getTitle();
+      const isQuestionPage =
         pageTitle.includes("Enter the") ||
         pageTitle.includes("What type") ||
         pageTitle.includes("Enter a");

--- a/feature-tests/tests/resources/step-definitions/ui/question-page.step.ts
+++ b/feature-tests/tests/resources/step-definitions/ui/question-page.step.ts
@@ -21,7 +21,7 @@ const feature = loadFeature(
 defineFeature(feature, (test) => {
   let driver: WebDriver;
 
-  let chromeOptions = new Options();
+  const chromeOptions = new Options();
   if (process.env.CI) {
     chromeOptions.addArguments("--no-sandbox");
     chromeOptions.addArguments("--whitelisted-ips= ");
@@ -59,8 +59,8 @@ defineFeature(feature, (test) => {
       /^I start the journey with the backend stub and nino (.*) for user (.*)$/,
       async (selectedNino, userId) => {
         await generateClaimsUrl(selectedNino, userId);
-        let encodedClaims = await postUpdatedClaimsUrl(false);
-        let contextPage: ContextPage = new ContextPage(driver);
+        const encodedClaims = await postUpdatedClaimsUrl(false);
+        const contextPage: ContextPage = new ContextPage(driver);
         await contextPage.goTo(
           EndPoints.FRONTEND +
             "/oauth2/authorize?request=" +
@@ -74,15 +74,15 @@ defineFeature(feature, (test) => {
     when(
       /^I select continue on the context page triggering fetch questions Request$/,
       async () => {
-        let contextPage: ContextPage = new ContextPage(driver);
+        const contextPage: ContextPage = new ContextPage(driver);
         expect(contextPage).toBeTruthy();
         await contextPage.clickContinue();
       }
     );
 
     then(/^I see a question page$/, async () => {
-      let pageTitle = await driver.getTitle();
-      let isQuestionPage =
+      const pageTitle = await driver.getTitle();
+      const isQuestionPage =
         pageTitle.includes("Enter the") ||
         pageTitle.includes("What type") ||
         pageTitle.includes("Enter a");
@@ -107,15 +107,15 @@ defineFeature(feature, (test) => {
     and(
       /^I should receive a VC with the correct verificationScore (.*) for a user with >=3 questions over 2 questionKey$/,
       async (verificationScore: string) => {
-        let stubPage: StubPage = new StubPage(driver);
+        const stubPage: StubPage = new StubPage(driver);
 
-        let summaryElement = await driver.findElements(
+        const summaryElement = await driver.findElements(
           By.xpath('//*[@id="main-content"]/div/details/summary')
         );
         if (summaryElement.length <= 0) {
-          let currentUrl = await driver.getCurrentUrl();
-          let urlWithoutPrefix = currentUrl.substring("https://".length);
-          let authUrl =
+          const currentUrl = await driver.getCurrentUrl();
+          const urlWithoutPrefix = currentUrl.substring("https://".length);
+          const authUrl =
             "https://" +
             EndPoints.CORE_STUB_USERNAME +
             ":" +
@@ -125,7 +125,7 @@ defineFeature(feature, (test) => {
           driver.get(authUrl);
         }
 
-        let vcText = await stubPage.getVc();
+        const vcText = await stubPage.getVc();
         expect(vcText).toContain(verificationScore);
         console.log("VC Data", vcText);
       }
@@ -142,8 +142,8 @@ defineFeature(feature, (test) => {
       /^I start the journey with the backend stub and nino (.*) for user (.*)$/,
       async (selectedNino, userId) => {
         await generateClaimsUrl(selectedNino, userId);
-        let encodedClaims = await postUpdatedClaimsUrl(false);
-        let contextPage: ContextPage = new ContextPage(driver);
+        const encodedClaims = await postUpdatedClaimsUrl(false);
+        const contextPage: ContextPage = new ContextPage(driver);
         await contextPage.goTo(
           EndPoints.FRONTEND +
             "/oauth2/authorize?request=" +
@@ -157,15 +157,15 @@ defineFeature(feature, (test) => {
     when(
       /^I select continue on the context page triggering fetch questions Request$/,
       async () => {
-        let contextPage: ContextPage = new ContextPage(driver);
+        const contextPage: ContextPage = new ContextPage(driver);
         expect(contextPage).toBeTruthy();
         await contextPage.clickContinue();
       }
     );
 
     then(/^I see a question page$/, async () => {
-      let pageTitle = await driver.getTitle();
-      let isQuestionPage =
+      const pageTitle = await driver.getTitle();
+      const isQuestionPage =
         pageTitle.includes("Enter the") ||
         pageTitle.includes("What type") ||
         pageTitle.includes("Enter a");
@@ -187,15 +187,15 @@ defineFeature(feature, (test) => {
     and(
       /^I should receive a VC with the correct verificationScore (.*) for a user with 2 questions over 2 questionKey$/,
       async (verificationScore: string) => {
-        let stubPage: StubPage = new StubPage(driver);
+        const stubPage: StubPage = new StubPage(driver);
 
-        let summaryElement = await driver.findElements(
+        const summaryElement = await driver.findElements(
           By.xpath('//*[@id="main-content"]/div/details/summary')
         );
         if (summaryElement.length <= 0) {
-          let currentUrl = await driver.getCurrentUrl();
-          let urlWithoutPrefix = currentUrl.substring("https://".length);
-          let authUrl =
+          const currentUrl = await driver.getCurrentUrl();
+          const urlWithoutPrefix = currentUrl.substring("https://".length);
+          const authUrl =
             "https://" +
             EndPoints.CORE_STUB_USERNAME +
             ":" +
@@ -205,7 +205,7 @@ defineFeature(feature, (test) => {
           driver.get(authUrl);
         }
 
-        let vcText = await stubPage.getVc();
+        const vcText = await stubPage.getVc();
         expect(vcText).toContain(verificationScore);
       }
     );
@@ -222,8 +222,8 @@ defineFeature(feature, (test) => {
       async (selectedNino, userId, firstName, familyName) => {
         await generateClaimsUrl(selectedNino, userId);
         await updateClaimsUrl(firstName, familyName);
-        let encodedClaims = await postUpdatedClaimsUrl(true);
-        let contextPage: ContextPage = new ContextPage(driver);
+        const encodedClaims = await postUpdatedClaimsUrl(true);
+        const contextPage: ContextPage = new ContextPage(driver);
         await contextPage.goTo(
           EndPoints.FRONTEND +
             "/oauth2/authorize?request=" +
@@ -237,15 +237,15 @@ defineFeature(feature, (test) => {
     when(
       /^I select continue on the context page calling fetch questions Request$/,
       async () => {
-        let contextPage: ContextPage = new ContextPage(driver);
+        const contextPage: ContextPage = new ContextPage(driver);
         expect(contextPage).toBeTruthy();
         await contextPage.clickContinue();
       }
     );
 
     then(/^I see the first question page$/, async () => {
-      let pageTitle = await driver.getTitle();
-      let isQuestionPage =
+      const pageTitle = await driver.getTitle();
+      const isQuestionPage =
         pageTitle.includes("Enter the") ||
         pageTitle.includes("What type") ||
         pageTitle.includes("Enter a");
@@ -270,15 +270,15 @@ defineFeature(feature, (test) => {
     and(
       /^I should receive a VC with the correct verificationScore (.*) for a HMRC user with >=3 questions over 2 questionKey$/,
       async (verificationScore: string) => {
-        let stubPage: StubPage = new StubPage(driver);
+        const stubPage: StubPage = new StubPage(driver);
 
-        let summaryElement = await driver.findElements(
+        const summaryElement = await driver.findElements(
           By.xpath('//*[@id="main-content"]/div/details/summary')
         );
         if (summaryElement.length <= 0) {
-          let currentUrl = await driver.getCurrentUrl();
-          let urlWithoutPrefix = currentUrl.substring("https://".length);
-          let authUrl =
+          const currentUrl = await driver.getCurrentUrl();
+          const urlWithoutPrefix = currentUrl.substring("https://".length);
+          const authUrl =
             "https://" +
             EndPoints.CORE_STUB_USERNAME +
             ":" +
@@ -288,7 +288,7 @@ defineFeature(feature, (test) => {
           driver.get(authUrl);
         }
 
-        let vcText = await stubPage.getVc();
+        const vcText = await stubPage.getVc();
         expect(vcText).toContain(verificationScore);
         console.log("VC Data Returned: ", vcText);
       }
@@ -296,9 +296,9 @@ defineFeature(feature, (test) => {
   });
 
   async function enterAnswer() {
-    let currentUrl = await driver.getCurrentUrl();
-    let currentPath = currentUrl.substring(currentUrl.lastIndexOf("/") + 1);
-    let questionFromUrl = await findObjectContainingValue(
+    const currentUrl = await driver.getCurrentUrl();
+    const currentPath = currentUrl.substring(currentUrl.lastIndexOf("/") + 1);
+    const questionFromUrl = await findObjectContainingValue(
       urlKeyMap,
       currentPath
     );
@@ -313,11 +313,11 @@ defineFeature(feature, (test) => {
     const objectProprty = Object.keys(postPayload!)[0];
     const postQuestionKey = postPayload![objectProprty];
 
-    let quesionPage: QuestionPage = new QuestionPage(driver);
+    const quesionPage: QuestionPage = new QuestionPage(driver);
 
     if (postQuestionKey.questionKey === "sa-payment-details") {
-      let saPaymentJson = JSON.parse(postQuestionKey.value);
-      let dateArray = saPaymentJson.paymentDate.split("-");
+      const saPaymentJson = JSON.parse(postQuestionKey.value);
+      const dateArray = saPaymentJson.paymentDate.split("-");
       await quesionPage.enterAnswer(
         dateArray[2],
         "selfAssessmentPaymentDate-day"
@@ -368,7 +368,7 @@ defineFeature(feature, (test) => {
   }
 
   async function clickContinue() {
-    let quesionPage: QuestionPage = new QuestionPage(driver);
+    const quesionPage: QuestionPage = new QuestionPage(driver);
     await quesionPage.clickContinue();
   }
 });

--- a/package.json
+++ b/package.json
@@ -48,5 +48,6 @@
     "ts-jest": "29.1.1",
     "ts-node": "10.9.1",
     "typescript": "5.3.3"
-  }
+  },
+  "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e"
 }


### PR DESCRIPTION
## Proposed changes

### What changed

Disabled Test Tags for all tests

All tests for UI and API have had test tags commented out (this includes all pre merge and post merge tests)  

Package.json script for Infrastructure template tests removed (disables the infra template tests) 

**Workflows:**

run-unit-tests.yml updated to remove Infra Tests from being run as part of unit tests  

### Why did it change

To ensure that tests dont execute unexpectedly during HMRC Close down tasks

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1517](https://govukverify.atlassian.net/browse/LIME-1517)



[LIME-1517]: https://govukverify.atlassian.net/browse/LIME-1517?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ