### PR TITLE
LIME-1466 - Rate limit higher environments but keep dev and pre-merge operational

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -151,56 +151,56 @@
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 115
+        "line_number": 106
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 123
+        "line_number": 114
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 131
+        "line_number": 122
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 139
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 147
+        "line_number": 138
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "a6f001558be9f15f42a6ddea2a1b8f7b6b914d2a",
         "is_verified": false,
-        "line_number": 156
+        "line_number": 147
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 167
+        "line_number": 158
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 203
+        "line_number": 202
       }
     ],
     "lambdas/dynamo-unmarshall/tests/dynamo-unmarshall-handler.test.ts": [
@@ -250,5 +250,5 @@
       }
     ]
   },
-  "generated_at": "2025-01-30T15:42:55Z"
+  "generated_at": "2025-01-31T17:09:27Z"
 }

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -151,56 +151,56 @@
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "aa1dd0ad4d2da161dd67db89e3d1aff921426385",
         "is_verified": false,
-        "line_number": 106
+        "line_number": 115
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "5f784906cd85d6336c8506e9da9d102405771429",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 123
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "1ef0d2ac7a97bfe12f63f5d79979f912500adae1",
         "is_verified": false,
-        "line_number": 122
+        "line_number": 131
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "5f399dc88587898510cf56b7503b482c870d0121",
         "is_verified": false,
-        "line_number": 130
+        "line_number": 139
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "dc2050b23f4157e1b630f2bdf2f0a76b82f0f51a",
         "is_verified": false,
-        "line_number": 138
+        "line_number": 147
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "a6f001558be9f15f42a6ddea2a1b8f7b6b914d2a",
         "is_verified": false,
-        "line_number": 147
+        "line_number": 156
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "b811ac90fe7fab03f6144a17aaebc38dcf3e007b",
         "is_verified": false,
-        "line_number": 158
+        "line_number": 167
       },
       {
         "type": "Secret Keyword",
         "filename": "infrastructure/template.yaml",
         "hashed_secret": "690de9fd42add772818ae392cb68a4f81d1511e3",
         "is_verified": false,
-        "line_number": 182
+        "line_number": 203
       }
     ],
     "lambdas/dynamo-unmarshall/tests/dynamo-unmarshall-handler.test.ts": [
@@ -250,5 +250,5 @@
       }
     ]
   },
-  "generated_at": "2024-10-04T12:19:38Z"
+  "generated_at": "2025-01-30T15:42:55Z"
 }

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -48,7 +48,7 @@ Parameters:
   UseApiKey:
     Type: String
     Default: "true"
-    Description: Value used to indicate if the public api should be protected by a api key.
+    Description: Value used to indicate if the public api should be protected by an api key.
   TxmaStackName:
     Description: "The stack containing the TXMA infrastructure"
     Type: String
@@ -65,15 +65,6 @@ Conditions:
     Fn::Equals:
       - !Ref DeploymentType
       - "pipeline"
-  IsHMRCDecommissioned: !Or
-    - !Equals [!Ref Environment, dev]
-    - !Equals [!Ref Environment, build]
-    - !Equals [!Ref Environment, staging]
-    - !Equals [!Ref Environment, integration]
-    - !Equals [!Ref Environment, production]
-  IsHMRCDecommissionedOrIsDeployedFromPipeline: !Or
-    - !Condition IsHMRCDecommissioned
-    - !Condition IsDeployedFromPipeline
   # Don't send logs in dev to avoid overwhelming the destination with debug
   LogSendingEnabled: !And
     - !Not [!Equals [!Ref Environment, "dev"]]
@@ -169,45 +160,55 @@ Mappings:
       VerifiableCredentialJwtTtlUnit: HOURS
       StateMachineLoggingIncludeExecutionData: true
       StateMachineLoggingLevel: "ALL"
-      throttleQuotaLimit: 0
-      throttleRateLimit: 0
-      throttleBurstLimit: 0
+      apiKeythrottleQuotaLimit: 1
+      apiKeythrottleRateLimit: 1
+      apiKeythrottleBurstLimit: 1
+      apiGatewayMethodThrottlingRateLimit: 1
+      apiGatewayMethodThrottlingBurstLimit: 1
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       VerifiableCredentialMaxJwtTtl: 2
       VerifiableCredentialJwtTtlUnit: HOURS
       StateMachineLoggingIncludeExecutionData: true
       StateMachineLoggingLevel: "ALL"
-      throttleQuotaLimit: 0
-      throttleRateLimit: 0
-      throttleBurstLimit: 0
+      apiKeythrottleQuotaLimit: 1
+      apiKeythrottleRateLimit: 1
+      apiKeythrottleBurstLimit: 1
+      apiGatewayMethodThrottlingRateLimit: 1
+      apiGatewayMethodThrottlingBurstLimit: 1
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       VerifiableCredentialMaxJwtTtl: 6
       VerifiableCredentialJwtTtlUnit: MONTHS
       StateMachineLoggingIncludeExecutionData: true
       StateMachineLoggingLevel: "ALL"
-      throttleQuotaLimit: 0
-      throttleRateLimit: 0
-      throttleBurstLimit: 0
+      apiKeythrottleQuotaLimit: 1
+      apiKeythrottleRateLimit: 1
+      apiKeythrottleBurstLimit: 1
+      apiGatewayMethodThrottlingRateLimit: 1
+      apiGatewayMethodThrottlingBurstLimit: 1
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       VerifiableCredentialMaxJwtTtl: 6
       VerifiableCredentialJwtTtlUnit: MONTHS
       StateMachineLoggingIncludeExecutionData: false # PII in state data
       StateMachineLoggingLevel: "ALL"
-      throttleQuotaLimit: 0
-      throttleRateLimit: 0
-      throttleBurstLimit: 0
+      apiKeythrottleQuotaLimit: 1
+      apiKeythrottleRateLimit: 1
+      apiKeythrottleBurstLimit: 1
+      apiGatewayMethodThrottlingRateLimit: 1
+      apiGatewayMethodThrottlingBurstLimit: 1
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       VerifiableCredentialMaxJwtTtl: 6
       VerifiableCredentialJwtTtlUnit: MONTHS
       StateMachineLoggingIncludeExecutionData: false # PII in state data
       StateMachineLoggingLevel: "ALL"
-      throttleQuotaLimit: 0
-      throttleRateLimit: 0
-      throttleBurstLimit: 0
+      apiKeythrottleQuotaLimit: 1
+      apiKeythrottleRateLimit: 1
+      apiKeythrottleBurstLimit: 1
+      apiGatewayMethodThrottlingRateLimit: 1
+      apiGatewayMethodThrottlingBurstLimit: 1
 
 Resources:
   ####################################################################
@@ -231,8 +232,18 @@ Resources:
           # Disable data trace in production to avoid logging customer sensitive information
           DataTraceEnabled: !If [IsProdEnvironment, false, true]
           MetricsEnabled: true
-          ThrottlingRateLimit: 50
-          ThrottlingBurstLimit: 100
+          ThrottlingRateLimit:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              apiGatewayMethodThrottlingRateLimit,
+            ]
+          ThrottlingBurstLimit:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              apiGatewayMethodThrottlingBurstLimit,
+            ]
       AccessLogSetting:
         DestinationArn: !GetAtt PublicKbvHmrcApiAccessLogGroup.Arn
         Format: >-
@@ -297,8 +308,18 @@ Resources:
           # Disable data trace in production to avoid logging customer sensitive information
           DataTraceEnabled: !If [IsProdEnvironment, false, true]
           MetricsEnabled: true
-          ThrottlingRateLimit: 50
-          ThrottlingBurstLimit: 100
+          ThrottlingRateLimit:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              apiGatewayMethodThrottlingRateLimit,
+            ]
+          ThrottlingBurstLimit:
+            !FindInMap [
+              EnvironmentConfiguration,
+              !Ref Environment,
+              apiGatewayMethodThrottlingBurstLimit,
+            ]
       AccessLogSetting:
         DestinationArn: !GetAtt PrivateKbvHmrcApiAccessLogGroup.Arn
         Format: >-
@@ -1282,62 +1303,59 @@ Resources:
 
   PublicKbvHmrcApiUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
-    Condition: IsHMRCDecommissionedOrIsDeployedFromPipeline
-    DependsOn:
-      - PublicKbvHmrcApiStage
+    Condition: IsDeployedFromPipeline
     Properties:
       ApiStages:
         - ApiId: !Ref PublicKbvHmrcApi
-          Stage: !Ref Environment
+          Stage: !Ref PublicKbvHmrcApi.Stage
       Quota:
         Limit:
           !FindInMap [
             EnvironmentConfiguration,
             !Ref Environment,
-            throttleQuotaLimit,
+            apiKeythrottleQuotaLimit,
           ]
         Period: DAY
       Throttle:
         RateLimit: !FindInMap [
             EnvironmentConfiguration,
             !Ref Environment,
-            throttleRateLimit,
+            apiKeythrottleRateLimit,
           ] # allowed requests per second
         BurstLimit: !FindInMap [
             EnvironmentConfiguration,
             !Ref Environment,
-            throttleBurstLimit,
+            apiKeythrottleBurstLimit,
           ] # requests the API can handle concurrently
+
   PrivateKbvHmrcApiUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
-    Condition: IsHMRCDecommissionedOrIsDeployedFromPipeline
-    DependsOn:
-      - PrivateKbvHmrcApiStage
+    Condition: IsDeployedFromPipeline
     Properties:
       ApiStages:
         - ApiId: !Ref PrivateKbvHmrcApi
-          Stage: !Ref Environment
+          Stage: !Ref PrivateKbvHmrcApi.Stage
       Quota:
         Limit:
           !FindInMap [
             EnvironmentConfiguration,
             !Ref Environment,
-            throttleQuotaLimit,
+            apiKeythrottleQuotaLimit,
           ]
         Period: DAY
       Throttle:
         RateLimit: !FindInMap [
             EnvironmentConfiguration,
             !Ref Environment,
-            throttleRateLimit,
+            apiKeythrottleRateLimit,
           ] # allowed requests per second
         BurstLimit: !FindInMap [
             EnvironmentConfiguration,
             !Ref Environment,
-            throttleBurstLimit,
+            apiKeythrottleBurstLimit,
           ] # requests the API can handle concurrently
   LinkUsagePlanApiKey1:
-    Condition: IsHMRCDecommissionedOrIsDeployedFromPipeline
+    Condition: IsDeployedFromPipeline
     Type: AWS::ApiGateway::UsagePlanKey
     Properties:
       KeyId: !ImportValue core-infrastructure-ApiKey1
@@ -1345,7 +1363,7 @@ Resources:
       UsagePlanId: !Ref PublicKbvHmrcApiUsagePlan
 
   LinkUsagePlanApiKey2:
-    Condition: IsHMRCDecommissionedOrIsDeployedFromPipeline
+    Condition: IsDeployedFromPipeline
     Type: AWS::ApiGateway::UsagePlanKey
     Properties:
       KeyId: !ImportValue core-infrastructure-ApiKey2

--- a/infrastructure/template.yaml
+++ b/infrastructure/template.yaml
@@ -65,6 +65,15 @@ Conditions:
     Fn::Equals:
       - !Ref DeploymentType
       - "pipeline"
+  IsHMRCDecommissioned: !Or
+    - !Equals [!Ref Environment, dev]
+    - !Equals [!Ref Environment, build]
+    - !Equals [!Ref Environment, staging]
+    - !Equals [!Ref Environment, integration]
+    - !Equals [!Ref Environment, production]
+  IsHMRCDecommissionedOrIsDeployedFromPipeline: !Or
+    - !Condition IsHMRCDecommissioned
+    - !Condition IsDeployedFromPipeline
   # Don't send logs in dev to avoid overwhelming the destination with debug
   LogSendingEnabled: !And
     - !Not [!Equals [!Ref Environment, "dev"]]
@@ -160,30 +169,45 @@ Mappings:
       VerifiableCredentialJwtTtlUnit: HOURS
       StateMachineLoggingIncludeExecutionData: true
       StateMachineLoggingLevel: "ALL"
+      throttleQuotaLimit: 0
+      throttleRateLimit: 0
+      throttleBurstLimit: 0
     build:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       VerifiableCredentialMaxJwtTtl: 2
       VerifiableCredentialJwtTtlUnit: HOURS
       StateMachineLoggingIncludeExecutionData: true
       StateMachineLoggingLevel: "ALL"
+      throttleQuotaLimit: 0
+      throttleRateLimit: 0
+      throttleBurstLimit: 0
     staging:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       VerifiableCredentialMaxJwtTtl: 6
       VerifiableCredentialJwtTtlUnit: MONTHS
       StateMachineLoggingIncludeExecutionData: true
       StateMachineLoggingLevel: "ALL"
+      throttleQuotaLimit: 0
+      throttleRateLimit: 0
+      throttleBurstLimit: 0
     integration:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceNonProductionVariables
       VerifiableCredentialMaxJwtTtl: 6
       VerifiableCredentialJwtTtlUnit: MONTHS
       StateMachineLoggingIncludeExecutionData: false # PII in state data
       StateMachineLoggingLevel: "ALL"
+      throttleQuotaLimit: 0
+      throttleRateLimit: 0
+      throttleBurstLimit: 0
     production:
       dynatraceSecretArn: arn:aws:secretsmanager:eu-west-2:216552277552:secret:DynatraceProductionVariables
       VerifiableCredentialMaxJwtTtl: 6
       VerifiableCredentialJwtTtlUnit: MONTHS
       StateMachineLoggingIncludeExecutionData: false # PII in state data
       StateMachineLoggingLevel: "ALL"
+      throttleQuotaLimit: 0
+      throttleRateLimit: 0
+      throttleBurstLimit: 0
 
 Resources:
   ####################################################################
@@ -1258,38 +1282,62 @@ Resources:
 
   PublicKbvHmrcApiUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
-    Condition: IsDeployedFromPipeline
-    # DependsOn:
-    #   - PublicKbvHmrcApiStage
+    Condition: IsHMRCDecommissionedOrIsDeployedFromPipeline
+    DependsOn:
+      - PublicKbvHmrcApiStage
     Properties:
       ApiStages:
         - ApiId: !Ref PublicKbvHmrcApi
           Stage: !Ref Environment
       Quota:
-        Limit: 100000
+        Limit:
+          !FindInMap [
+            EnvironmentConfiguration,
+            !Ref Environment,
+            throttleQuotaLimit,
+          ]
         Period: DAY
       Throttle:
-        RateLimit: 50 # allowed requests per second
-        BurstLimit: 100 # requests the API can handle concurrently
-
+        RateLimit: !FindInMap [
+            EnvironmentConfiguration,
+            !Ref Environment,
+            throttleRateLimit,
+          ] # allowed requests per second
+        BurstLimit: !FindInMap [
+            EnvironmentConfiguration,
+            !Ref Environment,
+            throttleBurstLimit,
+          ] # requests the API can handle concurrently
   PrivateKbvHmrcApiUsagePlan:
     Type: AWS::ApiGateway::UsagePlan
-    Condition: IsDeployedFromPipeline
-    # DependsOn:
-    #   - PrivateKbvHmrcApiStage
+    Condition: IsHMRCDecommissionedOrIsDeployedFromPipeline
+    DependsOn:
+      - PrivateKbvHmrcApiStage
     Properties:
       ApiStages:
         - ApiId: !Ref PrivateKbvHmrcApi
           Stage: !Ref Environment
       Quota:
-        Limit: 100000
+        Limit:
+          !FindInMap [
+            EnvironmentConfiguration,
+            !Ref Environment,
+            throttleQuotaLimit,
+          ]
         Period: DAY
       Throttle:
-        RateLimit: 50 # allowed requests per second
-        BurstLimit: 100 # requests the API can handle concurrently
-
+        RateLimit: !FindInMap [
+            EnvironmentConfiguration,
+            !Ref Environment,
+            throttleRateLimit,
+          ] # allowed requests per second
+        BurstLimit: !FindInMap [
+            EnvironmentConfiguration,
+            !Ref Environment,
+            throttleBurstLimit,
+          ] # requests the API can handle concurrently
   LinkUsagePlanApiKey1:
-    Condition: IsDeployedFromPipeline
+    Condition: IsHMRCDecommissionedOrIsDeployedFromPipeline
     Type: AWS::ApiGateway::UsagePlanKey
     Properties:
       KeyId: !ImportValue core-infrastructure-ApiKey1
@@ -1297,7 +1345,7 @@ Resources:
       UsagePlanId: !Ref PublicKbvHmrcApiUsagePlan
 
   LinkUsagePlanApiKey2:
-    Condition: IsDeployedFromPipeline
+    Condition: IsHMRCDecommissionedOrIsDeployedFromPipeline
     Type: AWS::ApiGateway::UsagePlanKey
     Properties:
       KeyId: !ImportValue core-infrastructure-ApiKey2


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- Include the Jira ticket number in square brackets as prefix, eg `[LIME-XXXX] PR Title` -->

## Proposed changes

### What changed

Rate limit higher environments but keep dev and pre-merge operational

### Why did it change

To reduce running costs of inactive environments.

### Issue tracking

<!-- List any related Jira tickets or GitHub issues -->

- [LIME-1466](https://govukverify.atlassian.net/browse/LIME-1466)

### Other considerations

<!-- Are there any further considerations to call out? e.g. changes in the README.md, new parameters added etc. -->


[LIME-1466]: https://govukverify.atlassian.net/browse/LIME-1466?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ